### PR TITLE
Add --input-sort-by option and fix failing conversion tests

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,7 @@
 ### Version 0.2.0 (in development)
 
 * Add an AppVeyor CI configuration file.
-* Add the `--input-sort-by` command-line option.
+* Add the `--sort-by` command-line option.
 
 ### Version 0.1.0 (08.01.2021)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ### Version 0.2.0 (in development)
 
 * Add an AppVeyor CI configuration file.
+* Add the `--input-sort-by` command-line option.
 
 ### Version 0.1.0 (08.01.2021)
 

--- a/README.md
+++ b/README.md
@@ -26,22 +26,22 @@ A Python tool that converts multiple NetCDF files to single Zarr datasets.
 $ nc2zarr --help
 Usage: nc2zarr [OPTIONS] [INPUT_FILE ...]
 
-  Reads one or more input datasets and writes or appends them to a single Zarr
-  output dataset.
+  Reads one or more input datasets and writes or appends them to a single
+  Zarr output dataset.
 
   INPUT_FILE may refer to a NetCDF file, or Zarr dataset, or a glob that
-  identifies multiple of them, e.g. "L3_SST/**/*.nc".
+  identifies multiple paths, e.g. "L3_SST/**/*.nc".
 
   OUTPUT_PATH must be directory which will contain the output Zarr dataset,
   e.g. "L3_SST.zarr".
 
-  CONFIG_FILE has YAML format. It comprises the optional objects "input",
-  "process", and "output". See nc2zarr/res/config-template.yml for a
-  template file that describes the format. Multiple --config options may be
-  passed as a chain to allow for reuse of credentials and other common
+  CONFIG_FILE must be in YAML format. It comprises the optional objects
+  "input", "process", and "output". See nc2zarr/res/config-template.yml for
+  a template file that describes the format. Multiple --config options may
+  be passed as a chain to allow for reuse of credentials and other common
   parameters. Contained configuration objects are recursively merged, lists
-  are appended, other values overwrite each other from left to right. For
-  example:
+  are appended, and other values overwrite each other from left to right.
+  For example:
 
   nc2zarr -c s3.yml -c common.yml -c inputs-01.yml -o out-01.zarr
   nc2zarr -c s3.yml -c common.yml -c inputs-02.yml -o out-02.zarr
@@ -51,39 +51,52 @@ Usage: nc2zarr [OPTIONS] [INPUT_FILE ...]
   configurations and thus overwrite settings in any CONFIG_FILE:
 
   [--dry-run] overwrites /dry_run
+  [--verbose] overwrites /verbosity
   [INPUT_FILE ...] overwrites /input/paths in CONFIG_FILE
   [--multi-file] overwrites /input/multi_file
   [--concat-dim] overwrites /input/concat_dim
   [--decode-cf] overwrites /input/decode_cf
+  [--input-sort-by] overwrites /input/sort_by
   [--output OUTPUT_FILE] overwrites /output/path
   [--overwrite] overwrites /output/overwrite
   [--append] overwrites /output/append
 
 Options:
-  -c, --config CONFIG_FILE   Configuration file (YAML). Multiple may be given.
-  -o, --output OUTPUT_PATH   Output name. Defaults to "out.zarr".
-  -d, --concat-dim DIM_NAME  Dimension for concatenation. Defaults to "time".
-  -m, --multi-file           Open multiple input files as one block. Works for
-                             NetCDF files only. Use --concat-dim to specify
-                             the dimension for concatenation.
+  -c, --config CONFIG_FILE        Configuration file (YAML). Multiple may be
+                                  given.
 
-  -w, --overwrite            Overwrite existing OUTPUT_PATH. If OUTPUT_PATH
-                             does not exist, the option has no effect. Cannot
-                             be used with --append.
+  -o, --output OUTPUT_PATH        Output name. Defaults to "out.zarr".
+  -d, --concat-dim DIM_NAME       Dimension for concatenation. Defaults to
+                                  "time".
 
-  -a, --append               Append inputs to existing OUTPUT_PATH. If
-                             OUTPUT_PATH does not exist, the option has no
-                             effect. Cannot be used with --overwrite.
+  -m, --multi-file                Open multiple input files as one block.
+                                  Works for NetCDF files only. Use --concat-
+                                  dim to specify the dimension for
+                                  concatenation.
 
-  --decode-cf                Decode variables according to CF conventions.
-                             Caution: array data may be converted to floating
-                             point type if a "_FillValue" attribute is
-                             present.
+  -w, --overwrite                 Overwrite existing OUTPUT_PATH. If
+                                  OUTPUT_PATH does not exist, the option has
+                                  no effect. Cannot be used with --append.
 
-  -d, --dry-run              Open and process inputs only, omit data writing.
-  -v, --verbose              Print more output.
-  --version                  Show version number and exit.
-  --help                     Show this message and exit.
+  -a, --append                    Append inputs to existing OUTPUT_PATH. If
+                                  OUTPUT_PATH does not exist, the option has
+                                  no effect. Cannot be used with --overwrite.
+
+  --decode-cf                     Decode variables according to CF
+                                  conventions. Caution: array data may be
+                                  converted to floating point type if a
+                                  "_FillValue" attribute is present.
+
+  -s, --input-sort-by [path|name]
+                                  Sort input files by specified property.
+  -d, --dry-run                   Open and process inputs only, omit data
+                                  writing.
+
+  -v, --verbose                   Print more output. Use twice for even more
+                                  output.
+
+  --version                       Show version number and exit.
+  --help                          Show this message and exit.
 ```
 
 ### Configuration file format

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Usage: nc2zarr [OPTIONS] [INPUT_FILE ...]
   [--multi-file] overwrites /input/multi_file
   [--concat-dim] overwrites /input/concat_dim
   [--decode-cf] overwrites /input/decode_cf
-  [--input-sort-by] overwrites /input/sort_by
+  [--sort-by] overwrites /input/sort_by
   [--output OUTPUT_FILE] overwrites /output/path
   [--overwrite] overwrites /output/overwrite
   [--append] overwrites /output/append
@@ -87,7 +87,7 @@ Options:
                                   converted to floating point type if a
                                   "_FillValue" attribute is present.
 
-  -s, --input-sort-by [path|name]
+  -s, --sort-by [path|name]
                                   Sort input files by specified property.
   -d, --dry-run                   Open and process inputs only, omit data
                                   writing.

--- a/nc2zarr/cli.py
+++ b/nc2zarr/cli.py
@@ -104,7 +104,7 @@ def nc2zarr(input_paths: Tuple[str],
     [--multi-file] overwrites /input/multi_file
     [--concat-dim] overwrites /input/concat_dim
     [--decode-cf] overwrites /input/decode_cf
-    [--input-sort-by] overwrites /input/sort_by
+    [--sort-by] overwrites /input/sort_by
     [--output OUTPUT_FILE] overwrites /output/path
     [--overwrite] overwrites /output/overwrite
     [--append] overwrites /output/append

--- a/nc2zarr/cli.py
+++ b/nc2zarr/cli.py
@@ -50,7 +50,7 @@ from nc2zarr.constants import DEFAULT_OUTPUT_PATH
               help=f'Decode variables according to CF conventions. '
                    f'Caution: array data may be converted to floating point type '
                    f'if a "_FillValue" attribute is present.')
-@click.option('--input-sort-by', '-s', 'input_sort_by', default=None,
+@click.option('--sort-by', '-s', 'sort_by', default=None,
               type=click.Choice(['path', 'name'], case_sensitive=True),
               help='Sort input files by specified property.')
 @click.option('--dry-run', '-d', 'dry_run', is_flag=True, default=None,
@@ -67,7 +67,7 @@ def nc2zarr(input_paths: Tuple[str],
             overwrite: bool,
             append: bool,
             decode_cf: bool,
-            input_sort_by: str,
+            sort_by: str,
             dry_run: bool,
             verbose: Tuple[bool],
             version: bool):
@@ -125,7 +125,7 @@ def nc2zarr(input_paths: Tuple[str],
                                     input_decode_cf=decode_cf,
                                     input_multi_file=multi_file,
                                     input_concat_dim=concat_dim,
-                                    input_sort_by=input_sort_by,
+                                    input_sort_by=sort_by,
                                     output_path=output_path,
                                     output_overwrite=overwrite,
                                     output_append=append,

--- a/nc2zarr/cli.py
+++ b/nc2zarr/cli.py
@@ -50,6 +50,9 @@ from nc2zarr.constants import DEFAULT_OUTPUT_PATH
               help=f'Decode variables according to CF conventions. '
                    f'Caution: array data may be converted to floating point type '
                    f'if a "_FillValue" attribute is present.')
+@click.option('--input-sort-by', '-s', 'input_sort_by', default=None,
+              type=click.Choice(['path', 'name'], case_sensitive=True),
+              help='Sort input files by specified property.')
 @click.option('--dry-run', '-d', 'dry_run', is_flag=True, default=None,
               help='Open and process inputs only, omit data writing.')
 @click.option('--verbose', '-v', 'verbose', is_flag=True, multiple=True,
@@ -64,6 +67,7 @@ def nc2zarr(input_paths: Tuple[str],
             overwrite: bool,
             append: bool,
             decode_cf: bool,
+            input_sort_by: str,
             dry_run: bool,
             verbose: Tuple[bool],
             version: bool):
@@ -117,6 +121,7 @@ def nc2zarr(input_paths: Tuple[str],
                                     input_decode_cf=decode_cf,
                                     input_multi_file=multi_file,
                                     input_concat_dim=concat_dim,
+                                    input_sort_by=input_sort_by,
                                     output_path=output_path,
                                     output_overwrite=overwrite,
                                     output_append=append,

--- a/nc2zarr/cli.py
+++ b/nc2zarr/cli.py
@@ -72,27 +72,30 @@ def nc2zarr(input_paths: Tuple[str],
             verbose: Tuple[bool],
             version: bool):
     """
-    Reads one or input datasets and writes or appends them to a single Zarr output dataset.
+    Reads one or more input datasets and writes or appends them to a single
+    Zarr output dataset.
 
-    INPUT_FILE may refer to a NetCDF file, or Zarr dataset, or a glob that identifies multiple
-    of them, e.g. "L3_SST/**/*.nc".
+    INPUT_FILE may refer to a NetCDF file, or Zarr dataset, or a glob that
+    identifies multiple paths, e.g. "L3_SST/**/*.nc".
 
-    OUTPUT_PATH must be directory which will contain the output Zarr dataset, e.g. "L3_SST.zarr".
+    OUTPUT_PATH must be directory which will contain the output Zarr dataset,
+    e.g. "L3_SST.zarr".
 
-    CONFIG_FILE has YAML format. It comprises the optional objects "input", "process", and "output".
+    CONFIG_FILE must be in YAML format. It comprises the optional objects
+    "input", "process", and "output".
     See nc2zarr/res/config-template.yml for a template file that describes the format.
     Multiple --config options may be passed as a chain to allow for
     reuse of credentials and other common parameters. Contained configuration objects
-    are recursively merged, lists are appended, other values overwrite each other from
-    left to right. For example:
+    are recursively merged, lists are appended, and other values overwrite each
+    other from left to right. For example:
 
     \b
     nc2zarr -c s3.yml -c common.yml -c inputs-01.yml -o out-01.zarr
     nc2zarr -c s3.yml -c common.yml -c inputs-02.yml -o out-02.zarr
     nc2zarr out-01.zarr out-02.zarr -o final.zarr
 
-    Command line arguments and options have precedence over other configurations and thus overwrite
-    settings in any CONFIG_FILE:
+    Command line arguments and options have precedence over other
+    configurations and thus overwrite settings in any CONFIG_FILE:
 
     \b
     [--dry-run] overwrites /dry_run
@@ -101,6 +104,7 @@ def nc2zarr(input_paths: Tuple[str],
     [--multi-file] overwrites /input/multi_file
     [--concat-dim] overwrites /input/concat_dim
     [--decode-cf] overwrites /input/decode_cf
+    [--input-sort-by] overwrites /input/sort_by
     [--output OUTPUT_FILE] overwrites /output/path
     [--overwrite] overwrites /output/overwrite
     [--append] overwrites /output/append

--- a/nc2zarr/res/config-template.yml
+++ b/nc2zarr/res/config-template.yml
@@ -49,9 +49,8 @@ input:
   # Sort resolved paths list.
   # - "name": sorts by file name
   # - "path": sorts by whole path
-  # - true: same as "path"
-  # - false: no sorting, order as provided
-  sort_by: false # true, "path" (= true), or "name"
+  # - null: no sorting, order as provided; globbed paths in arbitrary order
+  sort_by: null
   # Select given variables only. Comment out or set to null for all variables.
   variables:
     - <var_name_1>

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -69,7 +69,7 @@ class CliTest(MainTest, ZarrOutputTestMixin, IOCollector):
     def test_3_netcdf_inputs(self):
         self.add_inputs('inputs', day_offset=1, num_days=3)
         self.add_output('out.zarr')
-        result = self._invoke_cli(['--input-sort-by', 'path', 'inputs/*.nc'])
+        result = self._invoke_cli(['--sort-by', 'path', 'inputs/*.nc'])
         self.assertCliResultOk(result,
                                'out.zarr',
                                expected_vars={'lon', 'lat', 'time', 'r_ui16',

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -69,10 +69,11 @@ class CliTest(MainTest, ZarrOutputTestMixin, IOCollector):
     def test_3_netcdf_inputs(self):
         self.add_inputs('inputs', day_offset=1, num_days=3)
         self.add_output('out.zarr')
-        result = self._invoke_cli(['inputs/*.nc'])
+        result = self._invoke_cli(['--input-sort-by', 'path', 'inputs/*.nc'])
         self.assertCliResultOk(result,
                                'out.zarr',
-                               expected_vars={'lon', 'lat', 'time', 'r_ui16', 'r_i32', 'r_f32'},
+                               expected_vars={'lon', 'lat', 'time', 'r_ui16',
+                                              'r_i32', 'r_f32'},
                                expected_times=['2020-12-01T10:00:00',
                                                '2020-12-02T10:00:00',
                                                '2020-12-03T10:00:00'])

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -38,7 +38,7 @@ class MainTest(unittest.TestCase, IOCollector, ZarrOutputTestMixin):
     def test_defaults(self):
         self.add_inputs('inputs', day_offset=1, num_days=3)
         self.add_output('out.zarr')
-        Converter(input_paths='inputs/*.nc').run()
+        Converter(input_paths='inputs/*.nc', input_sort_by="path").run()
         self.assertZarrOutputOk('out.zarr',
                                 expected_vars={'lon', 'lat', 'time', 'r_ui16', 'r_i32', 'r_f32'},
                                 expected_times=['2020-12-01T10:00:00',
@@ -48,7 +48,8 @@ class MainTest(unittest.TestCase, IOCollector, ZarrOutputTestMixin):
     def test_explicit_append_dim(self):
         self.add_inputs('inputs', day_offset=1, num_days=3)
         self.add_output('out.zarr')
-        Converter(input_paths='inputs/*.nc', output_append_dim='time').run()
+        Converter(input_paths='inputs/*.nc', input_sort_by="path",
+                  output_append_dim='time').run()
         self.assertZarrOutputOk('out.zarr',
                                 expected_vars={'lon', 'lat', 'time', 'r_ui16', 'r_i32', 'r_f32'},
                                 expected_times=['2020-12-01T10:00:00',
@@ -64,7 +65,8 @@ class MainTest(unittest.TestCase, IOCollector, ZarrOutputTestMixin):
     def test_slices_with_overwrite(self):
         self.add_inputs('inputs', day_offset=1, num_days=3)
         self.add_output('out.zarr')
-        Converter(input_paths='inputs/*.nc', output_overwrite=True).run()
+        Converter(input_paths='inputs/*.nc', input_sort_by="path",
+                  output_overwrite=True).run()
         self.assertZarrOutputOk('out.zarr',
                                 expected_vars={'lon', 'lat', 'time', 'r_ui16', 'r_i32', 'r_f32'},
                                 expected_times=['2020-12-01T10:00:00',
@@ -84,7 +86,8 @@ class MainTest(unittest.TestCase, IOCollector, ZarrOutputTestMixin):
     def test_output(self):
         self.add_inputs('inputs', day_offset=1, num_days=3)
         self.add_output('my.zarr')
-        Converter(input_paths=['inputs/*.nc'], output_path='my.zarr').run()
+        Converter(input_paths=['inputs/*.nc'], input_sort_by="path",
+                  output_path='my.zarr').run()
         self.assertZarrOutputOk('my.zarr',
                                 expected_vars={'lon', 'lat', 'time', 'r_ui16', 'r_i32', 'r_f32'},
                                 expected_times=['2020-12-01T10:00:00',
@@ -94,7 +97,7 @@ class MainTest(unittest.TestCase, IOCollector, ZarrOutputTestMixin):
     def test_append_one_to_many(self):
         self.add_inputs('inputs', day_offset=1, num_days=3)
         self.add_output('out.zarr')
-        Converter(input_paths=['inputs/*.nc']).run()
+        Converter(input_paths=['inputs/*.nc'], input_sort_by="path").run()
         self.assertZarrOutputOk('out.zarr',
                                 expected_vars={'lon', 'lat', 'time', 'r_ui16', 'r_i32', 'r_f32'},
                                 expected_times=['2020-12-01T10:00:00',


### PR DESCRIPTION
Closes #8 .

 - Add the `--input-sort-by` option to the CLI
 - Explicitly specify the input sort order in several tests that were failing on CREODIAS due to an unexpected globbing sort order.