### PR TITLE
Custom Python processors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,25 @@
 ## nc2zarr Change History
 
+### Version 1.1.0 (in development)
+
+* You can now provide your Python code for customization 
+  of the datasets read and written. (#16)
+  - `input/custom_preprocessor: "module:function"` is called on 
+    each input after optional variable selection.
+  - `process/custom_processor: "module:function"` is called after 
+    optional renaming and before optional rechunking.
+
+  Both `"function"`s are expected to receive an `xarray.Dataset` object
+  as only argument and return the same or modified `xarray.Dataset` object.
+  Note: to let Python import `"module"` that is not a user package,
+  you can extend the `PYTHONPATH` environment variable before
+  calling `nc2zarr`:
+    ```
+    export PYTHONPATH=${PYTHONPATH}:path/to/my/modules
+    nc2zarr ...
+    ``` 
+
+
 ### Version 1.0.0 (26.02.2021)
 
 * Fixed some issues with Zarr (re-)chunking given by process parameter

--- a/nc2zarr/converter.py
+++ b/nc2zarr/converter.py
@@ -40,6 +40,7 @@ class Converter:
     :param input_paths:
     :param input_sort_by:
     :param input_variables:
+    :param input_custom_preprocessor:
     :param input_multi_file:
     :param input_concat_dim:
     :param input_engine:
@@ -47,6 +48,7 @@ class Converter:
     :param input_datetime_format:
     :param input_prefetch_chunks:
     :param process_rename:
+    :param process_custom_processor:
     :param process_rechunk:
     :param output_path:
     :param output_encoding:
@@ -63,6 +65,7 @@ class Converter:
                  input_paths: Union[str, Sequence[str]] = None,
                  input_sort_by: str = None,
                  input_variables: List[str] = None,
+                 input_custom_preprocessor: str = None,
                  input_multi_file: bool = False,
                  input_concat_dim: str = None,
                  input_engine: str = None,
@@ -70,6 +73,7 @@ class Converter:
                  input_datetime_format: str = None,
                  input_prefetch_chunks: bool = False,
                  process_rename: Dict[str, str] = None,
+                 process_custom_processor: str = None,
                  process_rechunk: Dict[str, Dict[str, int]] = None,
                  output_path: str = None,
                  output_encoding: Dict[str, Dict[str, Any]] = None,
@@ -98,6 +102,7 @@ class Converter:
         self.input_paths = input_paths
         self.input_sort_by = input_sort_by
         self.input_variables = input_variables
+        self.input_custom_preprocessor = input_custom_preprocessor
         self.input_multi_file = input_multi_file
         self.input_concat_dim = input_concat_dim
         self.input_engine = input_engine
@@ -105,6 +110,7 @@ class Converter:
         self.input_datetime_format = input_datetime_format
         self.input_prefetch_chunks = input_prefetch_chunks
         self.process_rename = process_rename
+        self.process_custom_processor = process_custom_processor
         self.process_rechunk = process_rechunk
         self.output_path = output_path
         self.output_encoding = output_encoding
@@ -135,10 +141,12 @@ class Converter:
                                input_prefetch_chunks=self.input_prefetch_chunks)
 
         pre_processor = DatasetPreProcessor(input_variables=self.input_variables,
+                                            input_custom_preprocessor=self.input_custom_preprocessor,
                                             input_concat_dim=self.input_concat_dim,
                                             input_datetime_format=self.input_datetime_format)
 
         processor = DatasetProcessor(process_rechunk=self.process_rechunk,
+                                     process_custom_processor=self.process_custom_processor,
                                      process_rename=self.process_rename,
                                      output_encoding=self.output_encoding)
 

--- a/nc2zarr/custom.py
+++ b/nc2zarr/custom.py
@@ -30,15 +30,19 @@ def load_custom_func(func_ref: str) -> Callable:
         if len(func_ref_parts) == 2:
             module_name, func_name = func_ref_parts
     if not module_name or not func_name:
-        raise ValueError(f'func_ref "{func_ref}" is invalid')
+        raise ValueError(f'func_ref "{func_ref}" is invalid, format must be <module>:<function>')
     try:
         module = importlib.import_module(module_name)
     except ImportError:
         raise ValueError(f'module for function "{func_ref}" not found')
-    try:
-        func = getattr(module, func_name)
-    except AttributeError:
-        raise ValueError(f'function "{func_ref}" not found')
-    if not callable(func):
+    obj = module
+    for attr_name in func_name.split('.'):
+        if not attr_name.isidentifier():
+            raise ValueError(f'func_ref "{func_ref}" is invalid, format must be <module>:<function>')
+        try:
+            obj = getattr(obj, attr_name)
+        except AttributeError:
+            raise ValueError(f'function "{func_ref}" not found, unknown attribute "{attr_name}"')
+    if not callable(obj):
         raise ValueError(f'"{func_ref}" is not callable')
-    return func
+    return obj

--- a/nc2zarr/custom.py
+++ b/nc2zarr/custom.py
@@ -1,0 +1,44 @@
+# The MIT License (MIT)
+# Copyright (c) 2021 by Brockmann Consult GmbH and contributors
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+# of the Software, and to permit persons to whom the Software is furnished to do
+# so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import importlib
+import importlib.util
+from typing import Callable
+
+
+def load_custom_func(func_ref: str) -> Callable:
+    module_name, func_name = '', ''
+    if isinstance(func_ref, str):
+        func_ref_parts = func_ref.rsplit(':', maxsplit=1)
+        if len(func_ref_parts) == 2:
+            module_name, func_name = func_ref_parts
+    if not module_name or not func_name:
+        raise ValueError(f'func_ref "{func_ref}" is invalid')
+    try:
+        module = importlib.import_module(module_name)
+    except ImportError:
+        raise ValueError(f'module for function "{func_ref}" not found')
+    try:
+        func = getattr(module, func_name)
+    except AttributeError:
+        raise ValueError(f'function "{func_ref}" not found')
+    if not callable(func):
+        raise ValueError(f'"{func_ref}" is not callable')
+    return func

--- a/nc2zarr/preprocessor.py
+++ b/nc2zarr/preprocessor.py
@@ -26,6 +26,7 @@ from typing import Tuple, Optional
 import pandas as pd
 import xarray as xr
 
+from .custom import load_custom_func
 from .error import ConverterError
 from .log import LOGGER
 
@@ -34,10 +35,13 @@ class DatasetPreProcessor:
     def __init__(self,
                  input_variables: List[str] = None,
                  input_concat_dim: str = None,
-                 input_datetime_format: str = None):
+                 input_datetime_format: str = None,
+                 input_custom_preprocessor: str = None):
         self._input_variables = input_variables
         self._input_concat_dim = input_concat_dim
         self._input_datetime_format = input_datetime_format
+        self._input_custom_preprocessor = load_custom_func(input_custom_preprocessor) \
+            if input_custom_preprocessor else None
         self._first_dataset_shown = False
 
     def preprocess_dataset(self, ds: xr.Dataset) -> xr.Dataset:
@@ -47,6 +51,8 @@ class DatasetPreProcessor:
         if self._input_concat_dim:
             ds = ensure_dataset_has_concat_dim(ds, self._input_concat_dim,
                                                datetime_format=self._input_datetime_format)
+        if self._input_custom_preprocessor is not None:
+            ds = self._input_custom_preprocessor(ds)
         if not self._first_dataset_shown:
             LOGGER.debug(f'First input dataset:\n{ds}')
             self._first_dataset_shown = True

--- a/nc2zarr/preprocessor.py
+++ b/nc2zarr/preprocessor.py
@@ -34,25 +34,25 @@ from .log import LOGGER
 class DatasetPreProcessor:
     def __init__(self,
                  input_variables: List[str] = None,
+                 input_custom_preprocessor: str = None,
                  input_concat_dim: str = None,
-                 input_datetime_format: str = None,
-                 input_custom_preprocessor: str = None):
+                 input_datetime_format: str = None):
         self._input_variables = input_variables
-        self._input_concat_dim = input_concat_dim
-        self._input_datetime_format = input_datetime_format
         self._input_custom_preprocessor = load_custom_func(input_custom_preprocessor) \
             if input_custom_preprocessor else None
+        self._input_concat_dim = input_concat_dim
+        self._input_datetime_format = input_datetime_format
         self._first_dataset_shown = False
 
     def preprocess_dataset(self, ds: xr.Dataset) -> xr.Dataset:
         if self._input_variables:
             drop_variables = set(ds.variables).difference(self._input_variables)
             ds = ds.drop_vars(drop_variables)
+        if self._input_custom_preprocessor is not None:
+            ds = self._input_custom_preprocessor(ds)
         if self._input_concat_dim:
             ds = ensure_dataset_has_concat_dim(ds, self._input_concat_dim,
                                                datetime_format=self._input_datetime_format)
-        if self._input_custom_preprocessor is not None:
-            ds = self._input_custom_preprocessor(ds)
         if not self._first_dataset_shown:
             LOGGER.debug(f'First input dataset:\n{ds}')
             self._first_dataset_shown = True

--- a/nc2zarr/processor.py
+++ b/nc2zarr/processor.py
@@ -23,21 +23,26 @@ from typing import Any, Tuple, Dict
 
 import xarray as xr
 
-_UNDEFINED = object()
+from .custom import load_custom_func
 
 
 class DatasetProcessor:
     def __init__(self,
                  process_rename: Dict[str, str] = None,
                  process_rechunk: Dict[str, Any] = None,
+                 process_custom_processor: str = None,
                  output_encoding: Dict[str, Dict[str, Any]] = None):
         self._process_rename = process_rename
         self._process_rechunk = process_rechunk
+        self._process_custom_processor = load_custom_func(process_custom_processor) \
+            if process_custom_processor else None
         self._output_encoding = output_encoding
 
     def process_dataset(self, ds: xr.Dataset) -> Tuple[xr.Dataset, Dict[str, Dict[str, Any]]]:
         if self._process_rename:
             ds = ds.rename(self._process_rename)
+        if self._process_custom_processor is not None:
+            ds = self._process_custom_processor(ds)
         if self._process_rechunk:
             ds, chunk_encoding = self._rechunk_dataset(ds, self._process_rechunk)
         else:

--- a/nc2zarr/res/config-template.yml
+++ b/nc2zarr/res/config-template.yml
@@ -77,6 +77,9 @@ input:
   # This may slow down the process slightly, but may be
   # required to avoid memory problems for very large inputs.
   prefetch_chunks: false
+  # A custom preprocessor.
+  # Called after variable selection.
+  custom_preprocessor: "my.package:my_preprocessor_func"
 
 # Configuration of input to output processing
 process:
@@ -109,6 +112,10 @@ process:
     <var_name>: null
     # Make chunk size for all dimensions of <var_name> same as input.
     <var_name>: "input"
+
+  # A custom processor.
+  # Called after variable renaming and before rechunking.
+  custom_processor: "my.package:my_processor_func"
 
 # Configuration of output
 output:

--- a/nc2zarr/res/config-template.yml
+++ b/nc2zarr/res/config-template.yml
@@ -41,52 +41,67 @@ verbosity: 0
 
 # Configuration of inputs
 input:
+
   # Input paths. May be passed as globs,
   # i.e. a path may contain '**', '*', and '?' wildcards.
   paths:
     - <input_path_or_glob_1>
     - <input_path_or_glob_2>
+
   # Sort resolved paths list.
   # - "name": sorts by file name
   # - "path": sorts by whole path
   # - null: no sorting, order as provided; globbed paths in arbitrary order
   sort_by: null
+
   # Select given variables only. Comment out or set to null for all variables.
   variables:
     - <var_name_1>
     - <var_name_2>
+
+  # A custom preprocessor.
+  # Called after variable selection.
+  custom_preprocessor: "module:function"
+
   # Read all input files as one block?
   # - true: Uses xarray.open_mfdataset(paths, ...)
   # - false: Uses xarray.open_dataset(paths[i], ...)
   multi_file: false
+
   # Name of dimension to be used for concatenation if multi_file is true.
   concat_dim: "time"
+
   # xarray engine used for opening the dataset
   engine: "netcdf4"
+
   # Whether to decode inputs according to CF conventions.
   # This is off by default, because we don't want any data interpretation.
   decode_cf: false
+
   # Optional date-time format when parsing time information from
   # a dataset's attributes such as "time_coverage_start", "time_coverage_end".
   # Most formats should be automatically detected, e.g. "20150101T103018Z"
   # or "2015-01-01 10:30:18".
   datetime_format: null
+
   # Open one input to fetch internal chunking, if any.
   # Then use this chunking to open all input files (and
   # foce using Dask arrays).
   # This may slow down the process slightly, but may be
   # required to avoid memory problems for very large inputs.
   prefetch_chunks: false
-  # A custom preprocessor.
-  # Called after variable selection.
-  custom_preprocessor: "my.package:my_preprocessor_func"
 
 # Configuration of input to output processing
 process:
+
   # Rename variables
   rename:
     <var_name>: <new_var_name>
     <var_name>: <new_var_name>
+
+  # A custom processor.
+  # Called after variable renaming and before rechunking.
+  custom_processor: "module:function"
 
   # (Re)chunk variable dimensions
   rechunk:
@@ -113,9 +128,6 @@ process:
     # Make chunk size for all dimensions of <var_name> same as input.
     <var_name>: "input"
 
-  # A custom processor.
-  # Called after variable renaming and before rechunking.
-  custom_processor: "my.package:my_processor_func"
 
 # Configuration of output
 output:
@@ -123,17 +135,22 @@ output:
   # "<bucket_name>/path/to/my.zarr" or "s3://<bucket_name>/path/to/my.zarr".
   # Otherwise it may be any local FS directory path.
   path: <output_path>
+
   # The "consolidated" keyword argument passed to xarray.Dataset.to_zarr().
   # Experimental Zarr feature. Improves access performance
   # for targets in object storage.
   consolidated: false
+
   # The "encoding" keyword argument passed to xarray.Dataset.to_zarr()
   # This is a mapping of variable names to variable encoding info.
   encoding: null
+
   # Overwrite existing dataset?
   overwrite: false
+
   # Append to existing dataset?
   append: false
+
   # Append dimension. Defaults to input/concat_dim or "time"
   append_dim: false
 

--- a/nc2zarr/version.py
+++ b/nc2zarr/version.py
@@ -1,1 +1,1 @@
-version = '1.0.0'
+version = '1.1.0.dev1'

--- a/tests/test_custom.py
+++ b/tests/test_custom.py
@@ -1,0 +1,61 @@
+# The MIT License (MIT)
+# Copyright (c) 2020 by Brockmann Consult GmbH and contributors
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+# of the Software, and to permit persons to whom the Software is furnished to do
+# so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import unittest
+
+from nc2zarr.custom import load_custom_func
+
+my_custom_var = 14
+
+
+def my_custom_func(*args, **kwargs):
+    return 14
+
+
+class LoadCustomFunctionTest(unittest.TestCase):
+
+    def test_ok(self):
+        func = load_custom_func("tests.test_custom:my_custom_func")
+        self.assertEqual(14, func())
+
+    def test_invalid(self):
+        with self.assertRaises(ValueError) as cm:
+            load_custom_func("tests.test_custom.my_custom_func")
+        self.assertEqual('func_ref "tests.test_custom.my_custom_func" is invalid',
+                         f"{cm.exception}")
+
+    def test_module_not_found(self):
+        with self.assertRaises(ValueError) as cm:
+            load_custom_func("test.test_custom:my_custom_func")
+        self.assertEqual('module for function "test.test_custom:my_custom_func" not found',
+                         f"{cm.exception}")
+
+    def test_function_not_found(self):
+        with self.assertRaises(ValueError) as cm:
+            load_custom_func("tests.test_custom:my_custom_fun")
+        self.assertEqual('function "tests.test_custom:my_custom_fun" not found',
+                         f"{cm.exception}")
+
+    def test_not_a_function(self):
+        with self.assertRaises(ValueError) as cm:
+            load_custom_func("tests.test_custom:my_custom_var")
+        self.assertEqual('"tests.test_custom:my_custom_var" is not callable',
+                         f"{cm.exception}")


### PR DESCRIPTION
You can now provide your Python code for customization of the datasets read and written. (#16)

- `input/custom_preprocessor: "module:function"` is called on each input after optional variable selection.
- `process/custom_processor: "module:function"` is called after optional renaming and before optional rechunking.

Both `"function"`s are expected to receive an `xarray.Dataset` object as only argument and return the same or modified `xarray.Dataset` object.

Note: to let Python import `"module"` that is not a user package, you can extend the `PYTHONPATH` environment variable before calling `nc2zarr`:

```
export PYTHONPATH=${PYTHONPATH}:path/to/my/modules
nc2zarr ...
``` 

**This PR has is already used for producing the CCI GHG CO2 Zarr dataset and seems to work as expected.**