### PR TITLE
Custom post-processor

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,7 @@
   - `output/custom_postprocessor: "module:function"` is called before 
     the final dataset is written. (#21)
 
-  All three `"function"`s are expected to receive an `xarray.Dataset` object
+  All three functions are expected to receive an `xarray.Dataset` object
   as only argument and return the same or modified `xarray.Dataset` object.
   Note: to let Python import `"module"` that is not a user package,
   you can extend the `PYTHONPATH` environment variable before

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,8 +8,10 @@
     each input after optional variable selection.
   - `process/custom_processor: "module:function"` is called after 
     optional renaming and before optional rechunking.
+  - `output/custom_postprocessor: "module:function"` is called before 
+    the final dataset is written. (#21)
 
-  Both `"function"`s are expected to receive an `xarray.Dataset` object
+  All three `"function"`s are expected to receive an `xarray.Dataset` object
   as only argument and return the same or modified `xarray.Dataset` object.
   Note: to let Python import `"module"` that is not a user package,
   you can extend the `PYTHONPATH` environment variable before

--- a/nc2zarr/converter.py
+++ b/nc2zarr/converter.py
@@ -57,11 +57,12 @@ class Converter:
     :param output_append:
     :param output_append_dim:
     :param output_s3:
+    :param output_custom_postprocessor:
     :param dry_run:
     :param verbosity:
     """
 
-    def __init__(self,
+    def __init__(self, *,
                  input_paths: Union[str, Sequence[str]] = None,
                  input_sort_by: str = None,
                  input_variables: List[str] = None,
@@ -83,6 +84,7 @@ class Converter:
                  output_append_dim: str = None,
                  output_s3: Dict[str, Any] = None,
                  output_retry: Dict[str, Any] = None,
+                 output_custom_postprocessor: str = False,
                  dry_run: bool = False,
                  verbosity: int = None):
 
@@ -113,6 +115,7 @@ class Converter:
         self.process_custom_processor = process_custom_processor
         self.process_rechunk = process_rechunk
         self.output_path = output_path
+        self.output_custom_postprocessor = output_custom_postprocessor
         self.output_encoding = output_encoding
         self.output_consolidated = output_consolidated
         self.output_overwrite = output_overwrite
@@ -151,6 +154,7 @@ class Converter:
                                      output_encoding=self.output_encoding)
 
         writer = DatasetWriter(output_path=self.output_path,
+                               output_custom_postprocessor=self.output_custom_postprocessor,
                                output_consolidated=self.output_consolidated,
                                output_encoding=self.output_encoding,
                                output_overwrite=self.output_overwrite,

--- a/nc2zarr/opener.py
+++ b/nc2zarr/opener.py
@@ -33,6 +33,7 @@ from .log import log_duration
 class DatasetOpener:
     def __init__(self,
                  input_paths: Union[str, List[str]],
+                 *,
                  input_multi_file: bool = False,
                  input_sort_by: str = None,
                  input_decode_cf: bool = False,

--- a/nc2zarr/preprocessor.py
+++ b/nc2zarr/preprocessor.py
@@ -32,7 +32,7 @@ from .log import LOGGER
 
 
 class DatasetPreProcessor:
-    def __init__(self,
+    def __init__(self, *,
                  input_variables: List[str] = None,
                  input_custom_preprocessor: str = None,
                  input_concat_dim: str = None,

--- a/nc2zarr/processor.py
+++ b/nc2zarr/processor.py
@@ -27,7 +27,7 @@ from .custom import load_custom_func
 
 
 class DatasetProcessor:
-    def __init__(self,
+    def __init__(self, *,
                  process_rename: Dict[str, str] = None,
                  process_rechunk: Dict[str, Any] = None,
                  process_custom_processor: str = None,

--- a/nc2zarr/res/config-template.yml
+++ b/nc2zarr/res/config-template.yml
@@ -59,7 +59,7 @@ input:
     - <var_name_1>
     - <var_name_2>
 
-  # An optional, custom preprocessor.
+  # An optional custom preprocessor.
   # Called after variable selection.
   custom_preprocessor: <module>:<function>
 

--- a/nc2zarr/res/config-template.yml
+++ b/nc2zarr/res/config-template.yml
@@ -136,7 +136,7 @@ output:
   # Otherwise it may be any local FS directory path.
   path: <output_path>
 
-  # An optional, custom post-processor.
+  # An optional custom post-processor.
   # Called before the data is written.
   custom_postprocessor: <module>:<function>
 

--- a/nc2zarr/res/config-template.yml
+++ b/nc2zarr/res/config-template.yml
@@ -99,7 +99,7 @@ process:
     <var_name>: <new_var_name>
     <var_name>: <new_var_name>
 
-  # An optional, custom processor.
+  # An optional custom processor.
   # Called after variable renaming and before rechunking.
   custom_processor: <module>:<function>
 

--- a/nc2zarr/res/config-template.yml
+++ b/nc2zarr/res/config-template.yml
@@ -59,9 +59,9 @@ input:
     - <var_name_1>
     - <var_name_2>
 
-  # A custom preprocessor.
+  # An optional, custom preprocessor.
   # Called after variable selection.
-  custom_preprocessor: "module:function"
+  custom_preprocessor: <module>:<function>
 
   # Read all input files as one block?
   # - true: Uses xarray.open_mfdataset(paths, ...)
@@ -99,9 +99,9 @@ process:
     <var_name>: <new_var_name>
     <var_name>: <new_var_name>
 
-  # A custom processor.
+  # An optional, custom processor.
   # Called after variable renaming and before rechunking.
-  custom_processor: "module:function"
+  custom_processor: <module>:<function>
 
   # (Re)chunk variable dimensions
   rechunk:
@@ -135,6 +135,10 @@ output:
   # "<bucket_name>/path/to/my.zarr" or "s3://<bucket_name>/path/to/my.zarr".
   # Otherwise it may be any local FS directory path.
   path: <output_path>
+
+  # An optional, custom post-processor.
+  # Called before the data is written.
+  custom_postprocessor: <module>:<function>
 
   # The "consolidated" keyword argument passed to xarray.Dataset.to_zarr().
   # Experimental Zarr feature. Improves access performance


### PR DESCRIPTION
Closes #21

* You can now provide your Python code for customization 
  of the datasets read and written. (#16)
  - `input/custom_preprocessor: "module:function"` is called on 
    each input after optional variable selection.
  - `process/custom_processor: "module:function"` is called after 
    optional renaming and before optional rechunking.
  - **`output/custom_postprocessor: "module:function"` is called before 
    the final dataset is written. (#21)**

  **All three** `"function"`s are expected to receive an `xarray.Dataset` object
  as only argument and return the same or modified `xarray.Dataset` object.
  Note: to let Python import `"module"` that is not a user package,
  you can extend the `PYTHONPATH` environment variable before
  calling `nc2zarr`:
    ```
    export PYTHONPATH=${PYTHONPATH}:path/to/my/modules
    nc2zarr ...
    ``` 
