### PR TITLE
Forman xxx batch cli

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,8 @@
   with `input.decode_cf = false` (the default) and for variables
   that defined a `scale_factor` and/or `add_offset` encoding
   attribute. (#35)
+  
+* Added a CLI tool `nc2zarr-batch`. 
 
 ### Version 1.1.1
 

--- a/nc2zarr/batch.py
+++ b/nc2zarr/batch.py
@@ -250,7 +250,11 @@ class BatchJob(ABC):
     def done(self) -> Optional[bool]:
         if self.status is JobStatus.UNKNOWN:
             return None
-        return self.status in (JobStatus.COMPLETED, JobStatus.FAILED, JobStatus.TERMINATED)
+        # Note: using Slurm, we'll never receive COMPLETED
+        return self.status in (JobStatus.COMPLETING,
+                               JobStatus.COMPLETED,
+                               JobStatus.FAILED,
+                               JobStatus.TERMINATED)
 
 
 class DryRunJob(BatchJob):

--- a/nc2zarr/batch.py
+++ b/nc2zarr/batch.py
@@ -20,6 +20,7 @@
 # SOFTWARE.
 
 import os.path
+import shlex
 import subprocess
 import threading
 import time
@@ -28,7 +29,6 @@ from typing import Dict, List, Any, Sequence, Tuple, Optional, TextIO, Type
 
 from .log import LOGGER, log_duration, use_verbosity
 
-import shlex
 
 class TemplateBatch:
     """

--- a/nc2zarr/cli.py
+++ b/nc2zarr/cli.py
@@ -59,18 +59,20 @@ from nc2zarr.constants import DEFAULT_OUTPUT_PATH
               help='Print more output. Use twice for even more output.')
 @click.option('--version', is_flag=True,
               help='Show version number and exit.')
-def nc2zarr(input_paths: Tuple[str],
-            output_path: str,
-            config_paths: Tuple[str],
-            multi_file: bool,
-            concat_dim: Optional[str],
-            overwrite: bool,
-            append: bool,
-            decode_cf: bool,
-            sort_by: str,
-            dry_run: bool,
-            verbose: int,
-            version: bool):
+def nc2zarr(
+        input_paths: Tuple[str],
+        output_path: str,
+        config_paths: Tuple[str],
+        multi_file: bool,
+        concat_dim: Optional[str],
+        overwrite: bool,
+        append: bool,
+        decode_cf: bool,
+        sort_by: str,
+        dry_run: bool,
+        verbose: int,
+        version: bool
+):
     """
     Reads one or more input datasets and writes or appends them to a single
     Zarr output dataset.
@@ -138,3 +140,112 @@ def nc2zarr(input_paths: Tuple[str],
 
 if __name__ == '__main__':
     nc2zarr()
+
+
+@click.command(name='nc2zarr-batch')
+@click.argument('config_template_path', metavar='CONFIG_TEMPLATE_PATH')
+@click.argument('config_path_template', metavar='CONFIG_PATH_TEMPLATE')
+@click.option('--range', '-R', 'ranges',
+              metavar='KEY MIN MAX', nargs=3, multiple=True,
+              help=f'Key value range assignments. MIN and MAX must be integers. Multiple may be given.')
+@click.option('--value', '-V', 'values',
+              metavar='KEY VALUE', nargs=2, multiple=True,
+              help=f'Key value assignments. Multiple may be given.')
+@click.option('--scheduler', '-s', 'scheduler_config_path',
+              metavar='FILE',
+              help=f'Scheduler configuration file (YAML).')
+@click.option('--dry-run', '-d', 'dry_run', is_flag=True, default=None,
+              help='Open and process inputs only, omit data writing.')
+@click.option('--verbose', '-v', 'verbose', count=True,
+              help='Print more output. Use twice for even more output.')
+def nc2zarr_batch(
+        config_template_path: str,
+        config_path_template: str,
+        ranges: Tuple[Tuple[str]],
+        values: Tuple[Tuple[str]],
+        scheduler_config_path: str,
+        dry_run: bool,
+        verbose: int
+):
+    """
+    Run nc2zarr in batch mode.
+
+    Example:
+
+    \b
+        $ nc2zarr-batch \\
+            --range year 2002 2017 \\
+            --value base_dir . \\
+            --scheduler ../slurm-config.yml \\
+            seaice/config-template.yml \\
+            seaice/batch/config-${year}.yml
+
+    """
+    import datetime
+    import time
+    import os.path
+    import itertools
+    import yaml
+
+    from nc2zarr.batch import TemplateBatch
+
+    if not os.path.isfile(config_template_path):
+        raise click.exceptions.FileError(config_template_path, 'not found')
+
+    for k, _, _ in ranges:
+        ref = "${" + k + "}"
+        if ref not in config_path_template:
+            raise click.exceptions.BadArgumentUsage(f'reference "{ref}" '
+                                                    f'missing in CONFIG_PATH_TEMPLATE')
+
+    # noinspection PyTypeChecker
+    product_args = [range(int(min_value), int(max_value) + 1) for _, min_value, max_value in ranges] \
+                   + [(value,) for _, value in values]
+
+    keys = [k for k, _, _ in ranges] + [k for k, _ in values]
+
+    config_template_variables = []
+    for values in itertools.product(*product_args):
+        config_template_variables.append({k: v for k, v in zip(keys, values)})
+
+    job_config = {}
+    if scheduler_config_path:
+        if not os.path.isfile(scheduler_config_path):
+            raise click.exceptions.FileError(scheduler_config_path, 'not found')
+        with open(scheduler_config_path) as fp:
+            job_config = yaml.load(fp, Loader=yaml.SafeLoader)
+
+    job_type = job_config.pop('type', 'local')
+    job_env_vars = job_config.pop('env_vars', {})
+    job_cwd_path = job_config.get('cwd_path', os.path.curdir)
+
+    if job_env_vars:
+        environ = dict(os.environ)
+        environ.update(job_env_vars)
+        job_env_vars = environ
+    python_path_ex = os.path.dirname(config_template_path) or '.'
+    python_path = job_env_vars.get('PYTHONPATH')
+    if python_path:
+        job_env_vars['PYTHONPATH'] = os.path.pathsep.join([python_path, python_path_ex])
+    else:
+        job_env_vars['PYTHONPATH'] = python_path_ex
+
+    batch = TemplateBatch(config_template_variables,
+                          config_template_path,
+                          config_path_template,
+                          dry_run=dry_run,
+                          verbosity=verbose)
+
+    jobs = batch.execute(nc2zarr_args=['-' + (max(1, verbose) * 'v')],
+                         job_type=job_type,
+                         job_env_vars=job_env_vars,
+                         job_cwd_path=job_cwd_path,
+                         **job_config)
+
+    while True:
+        print(f'\n{datetime.datetime.now()}:')
+        for values, job in zip(config_template_variables, jobs):
+            print(f'  {values}: {job.status}')
+        if all([job.done for job in jobs]):
+            break
+        time.sleep(2.0)

--- a/nc2zarr/cli.py
+++ b/nc2zarr/cli.py
@@ -147,7 +147,7 @@ if __name__ == '__main__':
 @click.argument('config_path_template', metavar='CONFIG_PATH_TEMPLATE')
 @click.option('--range', '-R', 'ranges',
               metavar='KEY MIN MAX', nargs=3, multiple=True,
-              help=f'Key value range assignments. MIN and MAX must be integers. Multiple may be given.')
+              help=f'Key value range assignments. MIN and MAX must be integers. Option may be repeated.')
 @click.option('--value', '-V', 'values',
               metavar='KEY VALUE', nargs=2, multiple=True,
               help=f'Key value assignments. Option may be repeated.')

--- a/nc2zarr/cli.py
+++ b/nc2zarr/cli.py
@@ -150,7 +150,7 @@ if __name__ == '__main__':
               help=f'Key value range assignments. MIN and MAX must be integers. Multiple may be given.')
 @click.option('--value', '-V', 'values',
               metavar='KEY VALUE', nargs=2, multiple=True,
-              help=f'Key value assignments. Multiple may be given.')
+              help=f'Key value assignments. Option may be repeated.')
 @click.option('--scheduler', '-s', 'scheduler_config_path',
               metavar='FILE',
               help=f'Scheduler configuration file (YAML).')

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup(
     entry_points={
         'console_scripts': [
             'nc2zarr = nc2zarr.cli:nc2zarr',
+            'nc2zarr-batch = nc2zarr.cli:nc2zarr_batch',
         ],
     },
 )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -36,27 +36,44 @@ from tests.helpers import ZarrOutputTestMixin
 
 class CliTest(unittest.TestCase):
 
-    def _invoke_cli(self, args: List[str], main: Callable = nc2zarr):
+    def invoke_cli(self, args: List[str], main: Callable = nc2zarr):
         self.runner = click.testing.CliRunner()
         return self.runner.invoke(main, args, catch_exceptions=False)
 
     @staticmethod
-    def _dump_cli_output(result):
+    def dump_cli_output(result):
         if result.stderr_bytes:
             print(f'stderr: {result.stderr_bytes.decode("utf-8")}')
         if result.stdout_bytes:
             print(f'stdout: {result.stdout_bytes.decode("utf-8")}')
 
+    def assertCliResult(self,
+                        result,
+                        expected_exit_code: int = None,
+                        expected_stdout: str = None,
+                        expected_stderr: str = None):
+        if expected_exit_code is not None:
+            if result.exit_code != expected_exit_code:
+                self.dump_cli_output(result)
+            self.assertEqual(expected_exit_code,
+                             result.exit_code)
+        if expected_stdout is not None:
+            self.assertIn(expected_stdout,
+                          result.stdout_bytes.decode("utf-8") if result.stdout_bytes else '')
+        if expected_stderr is not None:
+            self.assertIn(expected_stderr,
+                          result.stderr_bytes.decode("utf-8") if result.stderr_bytes else '')
+
 
 class NoOpNc2zarrCliTest(CliTest):
     def test_noargs(self):
-        self.assertEqual(1, self._invoke_cli([]).exit_code)
+        self.assertCliResult(self.invoke_cli([]), expected_exit_code=1)
 
     def test_version(self):
-        self.assertEqual(0, self._invoke_cli(['--version']).exit_code)
+        self.assertCliResult(self.invoke_cli(['--version']), expected_exit_code=0)
 
     def test_help(self):
-        self.assertEqual(0, self._invoke_cli(['--help']).exit_code)
+        self.assertCliResult(self.invoke_cli(['--help']), expected_exit_code=0)
 
     def test_help_main(self):
         subprocess.call([sys.executable, '-m', 'nc2zarr.cli', '--help'])
@@ -71,14 +88,15 @@ class Nc2zarrCliTest(CliTest, ZarrOutputTestMixin, IOCollector):
 
     def test_0_inputs(self):
         self.add_output('out.zarr')
-        result = self._invoke_cli([])
-        self.assertCliResultError(result, 1,
-                                  expected_stdout='Error: At least one input must be given.')
+        result = self.invoke_cli([])
+        self.assertCliResult(result,
+                             expected_exit_code=1,
+                             expected_stdout='Error: At least one input must be given.')
 
     def test_3_netcdf_inputs(self):
         self.add_inputs('inputs', day_offset=1, num_days=3)
         self.add_output('out.zarr')
-        result = self._invoke_cli(['--sort-by', 'path', 'inputs/*.nc'])
+        result = self.invoke_cli(['--sort-by', 'path', 'inputs/*.nc'])
         self.assertCliResultOk(result,
                                'out.zarr',
                                expected_vars={'lon', 'lat', 'time', 'r_ui16',
@@ -93,39 +111,21 @@ class Nc2zarrCliTest(CliTest, ZarrOutputTestMixin, IOCollector):
                           expected_vars: Collection[str],
                           expected_times: Collection[str]):
         if result.exit_code != 0:
-            self._dump_cli_output(result)
+            self.dump_cli_output(result)
         self.assertEqual(0, result.exit_code)
         self.assertZarrOutputOk(expected_output_path,
                                 expected_vars=expected_vars,
                                 expected_times=expected_times)
 
-    def assertCliResultError(self,
-                             result,
-                             expected_error_code: int = None,
-                             expected_stdout: str = None,
-                             expected_stderr: str = None):
-        if result.exit_code != 0:
-            self._dump_cli_output(result)
-
-        if expected_error_code is not None:
-            self.assertEqual(expected_error_code, result.exit_code)
-        else:
-            self.assertTrue(result.exit_code != 0)
-
-        if expected_stdout is not None:
-            self.assertIn(expected_stdout,
-                          result.stdout_bytes.decode("utf-8") if result.stdout_bytes else '')
-        if expected_stderr is not None:
-            self.assertIn(expected_stderr,
-                          result.stderr_bytes.decode("utf-8") if result.stderr_bytes else '')
-
 
 class NoOpNc2zarrBatchCliTest(CliTest):
     def test_noargs(self):
-        self.assertEqual(2, self._invoke_cli([], main=nc2zarr_batch).exit_code)
+        self.assertCliResult(self.invoke_cli([], main=nc2zarr_batch),
+                             expected_exit_code=2)
 
     def test_help(self):
-        self.assertEqual(0, self._invoke_cli(['--help'], main=nc2zarr_batch).exit_code)
+        self.assertCliResult(self.invoke_cli(['--help'], main=nc2zarr_batch),
+                             expected_exit_code=0)
 
 
 class Nc2zarrBatchCliTest(CliTest, ZarrOutputTestMixin, IOCollector):
@@ -134,6 +134,44 @@ class Nc2zarrBatchCliTest(CliTest, ZarrOutputTestMixin, IOCollector):
 
     def tearDown(self):
         self.delete_paths()
+
+    def test_config_template_path_not_found(self):
+        result = self.invoke_cli(['--range', 'year', '2010', '2013',
+                                  f'config-template.yml',
+                                  'batch/${year}.yml'],
+                                 main=nc2zarr_batch)
+        self.assertCliResult(result,
+                             expected_exit_code=1,
+                             expected_stdout='Error: Could not open file config-template.yml: not found')
+
+    def test_config_path_template_invalid(self):
+        # create empty file so it exists
+        self.add_path('config-template.yml')
+        with open('config-template.yml', 'w') as fp:
+            fp.write('')
+
+        result = self.invoke_cli(['--range', 'year', '2010', '2013',
+                                  f'config-template.yml',
+                                  'batch/${YEAR}.yml'],
+                                 main=nc2zarr_batch)
+        self.assertCliResult(result,
+                             expected_exit_code=2,
+                             expected_stdout='Error: reference "${year}" missing in CONFIG_PATH_TEMPLATE')
+
+    def test_scheduler_config_not_found(self):
+        # create empty file so it exists
+        self.add_path('config-template.yml')
+        with open('config-template.yml', 'w') as fp:
+            fp.write('')
+
+        result = self.invoke_cli(['--range', 'year', '2010', '2013',
+                                  '--scheduler', 'local.yml',
+                                  f'config-template.yml',
+                                  'batch/${year}.yml'],
+                                 main=nc2zarr_batch)
+        self.assertCliResult(result,
+                             expected_exit_code=1,
+                             expected_stdout='Error: Could not open file local.yml: not found')
 
     def test_fully_configured_run(self):
         base_dir = os.path.dirname(__file__)
@@ -155,16 +193,15 @@ class Nc2zarrBatchCliTest(CliTest, ZarrOutputTestMixin, IOCollector):
 
         self.add_path(f'{base_dir}/batch')
         self.add_path(f'{base_dir}/outputs')
-        result = self._invoke_cli(['--range', 'year', '2010', '2013',
-                                   '--value', 'base_dir', base_dir,
-                                   '--scheduler', f'{base_dir}/local-config.yml',
-                                   f'{base_dir}/config-template.yml',
-                                   '${base_dir}/batch/${year}.yml'],
-                                  main=nc2zarr_batch)
+        result = self.invoke_cli(['--range', 'year', '2010', '2013',
+                                  '--value', 'base_dir', base_dir,
+                                  '--scheduler', f'{base_dir}/local-config.yml',
+                                  f'{base_dir}/config-template.yml',
+                                  '${base_dir}/batch/${year}.yml'],
+                                 main=nc2zarr_batch)
 
-        if result.exit_code != 0:
-            self._dump_cli_output(result)
-            self.fail(f'failed with exit code {result.exit_code}')
+        self.assertCliResult(result,
+                             expected_exit_code=0)
 
         self.assertEqual({
             '2010.err',

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -28,6 +28,7 @@ from typing import List, Collection, Callable, Union, Optional
 import click
 import click.testing
 
+from nc2zarr.cli import expand_config_template_variables
 from nc2zarr.cli import nc2zarr
 from nc2zarr.cli import nc2zarr_batch
 from tests.helpers import IOCollector
@@ -239,3 +240,16 @@ class Nc2zarrBatchCliTest(CliTest, ZarrOutputTestMixin, IOCollector):
             '2012.zarr',
             '2013.zarr',
         }, set(os.listdir(f'{base_dir}/outputs')))
+
+
+class ConfigTemplateVariablesTest(unittest.TestCase):
+
+    def test_expand_config_template_variables(self):
+        self.assertEqual([],
+                         expand_config_template_variables((), ()))
+        self.assertEqual([{'base_dir': '.', 'year': 2010},
+                          {'base_dir': '.', 'year': 2011},
+                          {'base_dir': '.', 'year': 2012},
+                          {'base_dir': '.', 'year': 2013}],
+                         expand_config_template_variables((('year', '2010', '2013'),),
+                                                          (('base_dir', '.'),)))


### PR DESCRIPTION
Added new CLI tool `nc2zarr-batch` and tests. 

It is lacking some documentation still, which I'd like to add after we used the tool for a while. I'm generating ESA CCI CLOUD Zarr with it at this time, and it seems to do very much what is should do.

Usage:

```bash
$ nc2zarr-batch --help
Usage: nc2zarr-batch [OPTIONS] CONFIG_TEMPLATE_PATH CONFIG_PATH_TEMPLATE

  Run nc2zarr in batch mode.

  Example:

      $ nc2zarr-batch \
          --range year 2002 2017 \
          --value base_dir . \
          --scheduler ../slurm-config.yml \
          seaice/config-template.yml \
          seaice/batch/config-${year}.yml

Options:
  -R, --range KEY MIN MAX  Key value range assignments. MIN and MAX must be
                           integers. Multiple may be given.

  -V, --value KEY VALUE    Key value assignments. Multiple may be given.
  -s, --scheduler FILE     Scheduler configuration file (YAML).
  -d, --dry-run            Open and process inputs only, omit data writing.
  -v, --verbose            Print more output. Use twice for even more output.
  --help                   Show this message and exit.
```