### PR TITLE
Forman 38 drop vars

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,11 @@
 
 ### Version 1.1.2 (in development)
 
+* Fixed a problem that avoided appending datasets that contained variables
+  with `dtype = "|S1"` (ESA SST CCI). Such variables are no longer 
+  appended at all given that they do not contain the dimension along we 
+  append. Otherwise `nc2zarr` will still fail. (#38) 
+
 * Fixed a severe problem where data was "encoded" twice before 
   being appended to existing data. The bug became apparent
   with `input.decode_cf = false` (the default) and for variables

--- a/nc2zarr/writer.py
+++ b/nc2zarr/writer.py
@@ -26,6 +26,7 @@ import fsspec
 import fsspec.implementations.local
 import retry.api
 import xarray as xr
+import numpy as np
 
 from .constants import DEFAULT_OUTPUT_APPEND_DIM_NAME
 from .constants import DEFAULT_OUTPUT_RETRY_KWARGS
@@ -128,7 +129,8 @@ class DatasetWriter:
             append_dim = self._output_append_dim
             ds = ds.drop_vars([var_name
                                for var_name, var in ds.data_vars.items()
-                               if append_dim not in var.dims])
+                               if append_dim not in var.dims
+                               and np.issubdtype(var.dtype, 'S')])
 
             if not self._input_decode_cf:
                 # Fix for https://github.com/bcdev/nc2zarr/issues/35


### PR DESCRIPTION
Fixed a problem that avoided appending datasets that contained variables with `dtype = "|S1"` (ESA SST CCI). Such variables are no longer appended at all given that they do not contain the dimension along we append. Otherwise `nc2zarr` will still fail. 

Closes #38