### PR TITLE
Update output metadata on finalize

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,20 +2,24 @@
 
 ### Version 1.1.2 (in development)
 
-* Whether to adjust output metadata (global attributes)
-  after the last write/append can now be forced by the new
-  `output.adjust_metadata` setting whose default is `false`.
-  If set to `true`, this will adjust the
-  following metadata attributes
+* Whether to adjust output metadata (global attributes) after the last 
+  write/append can now be forced by the new `output.adjust_metadata` 
+  setting whose default is `false`. If set to `true`, this will adjust 
+  the following metadata attributes:
   - "history"
   - "source"
-  - "time_coverage_start" (and "start_time" if existed before)
-  - "time_coverage_end" (and "stop_time" if existed before)
+  - "time_coverage_start"
+  - "time_coverage_end" 
     
   In addition, extra metadata (global attributes) can now be added 
   after the last write/append using the new setting
   `output.metadata` whose value is a mapping from attribute 
-  names to values. (#20, #34)
+  names to values. 
+  
+  The above functionality is also reflected in two new CLI options
+  `--adjust-metadata` and `--finalize-only`. In combination, they
+  can be used to later adjust metadata in already existing Zarr 
+  datasets. (#20, #34)
   
 * Fixed a problem that avoided appending datasets that contained variables
   with `dtype = "|S1"` (ESA SST CCI). Such variables are written initially, 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,21 @@
 
 ### Version 1.1.2 (in development)
 
+* Whether to adjust output metadata (global attributes)
+  after the last write/append can now be forced by the new
+  `output.adjust_metadata` setting whose default is `false`.
+  If set to `true`, this will adjust the
+  following metadata attributes
+  - "history"
+  - "source"
+  - "time_coverage_start" (and "start_time" if existed before)
+  - "time_coverage_end" (and "stop_time" if existed before)
+    
+  In addition, extra metadata (global attributes) can now be added 
+  after the last write/append using the new setting
+  `output.metadata` whose value is a mapping from attribute 
+  names to values. (#20, #34)
+  
 * Fixed a problem that avoided appending datasets that contained variables
   with `dtype = "|S1"` (ESA SST CCI). Such variables are written initially, 
   but then no longer appended at all given that they do not contain the 

--- a/examples/scripts/set_date_attrs.py
+++ b/examples/scripts/set_date_attrs.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+
+"""set_date_attrs.py: Update a Zarr's start_date and stop_date attributes
+
+Given a Zarr store with a time dimension, this script sets its start_date
+and stop_date attributes (using the format YYYY-MM-DD) to match the first
+and last time values in the data.
+"""
+
+import argparse
+import pandas as pd
+import xarray as xr
+import zarr
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("zarr", metavar="PATH_OR_URL",
+                        description="Update a Zarr's start_date and"
+                        "stop_date attributes to match its data.")
+    parser.add_argument("--dry-run", "-d", action="store_true",
+                        help="Don't actually write metadata")
+    parser.add_argument("--verbose", "-v", action="store_true",
+                        help="Report progress to standard output")
+    args = parser.parse_args()
+    ds = xr.open_zarr(args.zarr)
+    z = zarr.open(args.zarr)
+    t0 = ds.time[0].values
+    t1 = ds.time[-1].values
+    if args.verbose:
+        print("First/last times:", t0, t1)
+    new_attrs = dict(
+        start_date=pd.to_datetime(t0).strftime("%Y-%m-%d"),
+        stop_date=pd.to_datetime(t1).strftime("%Y-%m-%d")
+    )
+    if args.verbose:
+        for title, dic in ("Old", z.attrs), ("New", new_attrs):
+            print(f"{title} attributes:")
+            for key in "start_date", "stop_date":
+                print(f'    {key}: ' +
+                      (dic[key] if key in dic else "not present"))
+    if args.dry_run:
+        if args.verbose:
+            print("Dry run -- not updating.")
+    else:
+        z.attrs.update(new_attrs)
+        zarr.consolidate_metadata(args.zarr)
+        if args.verbose:
+            print("Attributes updated.")
+
+
+if __name__ == "__main__":
+    main()

--- a/nc2zarr/cli.py
+++ b/nc2zarr/cli.py
@@ -27,6 +27,11 @@ from nc2zarr.constants import DEFAULT_OUTPUT_APPEND_DIM_NAME
 from nc2zarr.constants import DEFAULT_OUTPUT_PATH
 
 
+# Important note: when adding new options, make sure their default
+# value is None, otherwise the default values will override any value
+# given in the configuration files.
+
+
 @click.command(name='nc2zarr')
 @click.argument('input_paths', nargs=-1, metavar='[INPUT_FILE ...]')
 @click.option('--config', '-c', 'config_paths', metavar='CONFIG_FILE', multiple=True,
@@ -53,10 +58,10 @@ from nc2zarr.constants import DEFAULT_OUTPUT_PATH
 @click.option('--sort-by', '-s', 'sort_by', default=None,
               type=click.Choice(['path', 'name'], case_sensitive=True),
               help='Sort input files by specified property.')
-@click.option('--adjust-metadata', 'adjust_metadata', is_flag=True,
+@click.option('--adjust-metadata', 'adjust_metadata', is_flag=True, default=None,
               help=f'Adjust metadata attributes after the last '
                    f'write/append step.')
-@click.option('--finalize-only', 'finalize_only', is_flag=True,
+@click.option('--finalize-only', 'finalize_only', is_flag=True, default=None,
               help=f'Whether to just run "finalize" tasks on an existing '
                    f'output dataset. Currently, this updates the metadata only, '
                    f'given that configuration output/adjust_metadata is set or '

--- a/nc2zarr/cli.py
+++ b/nc2zarr/cli.py
@@ -53,6 +53,15 @@ from nc2zarr.constants import DEFAULT_OUTPUT_PATH
 @click.option('--sort-by', '-s', 'sort_by', default=None,
               type=click.Choice(['path', 'name'], case_sensitive=True),
               help='Sort input files by specified property.')
+@click.option('--adjust-metadata', 'adjust_metadata', is_flag=True,
+              help=f'Adjust metadata attributes after the last '
+                   f'write/append step.')
+@click.option('--finalize-only', 'finalize_only', is_flag=True,
+              help=f'Whether to just run "finalize" tasks on an existing '
+                   f'output dataset. Currently, this updates the metadata only, '
+                   f'given that configuration output/adjust_metadata is set or '
+                   f'output/metadata is not empty. '
+                   f'See also option --adjust-metadata.')
 @click.option('--dry-run', '-d', 'dry_run', is_flag=True, default=None,
               help='Open and process inputs only, omit data writing.')
 @click.option('--verbose', '-v', 'verbose', count=True,
@@ -69,6 +78,8 @@ def nc2zarr(
         append: bool,
         decode_cf: bool,
         sort_by: str,
+        adjust_metadata: bool,
+        finalize_only: bool,
         dry_run: bool,
         verbose: int,
         version: bool
@@ -100,16 +111,20 @@ def nc2zarr(
     configurations and thus override settings in any CONFIG_FILE:
 
     \b
+    [--finalize_only] overrides /finalize_only
     [--dry-run] overrides /dry_run
     [--verbose] overrides /verbosity
+
     [INPUT_FILE ...] overrides /input/paths in CONFIG_FILE
     [--multi-file] overrides /input/multi_file
     [--concat-dim] overrides /input/concat_dim
     [--decode-cf] overrides /input/decode_cf
     [--sort-by] overrides /input/sort_by
+
     [--output OUTPUT_FILE] overrides /output/path
     [--overwrite] overrides /output/overwrite
     [--append] overrides /output/append
+    [--adjust-metadata] overrides /output/adjust_metadata
     """
 
     if version:
@@ -131,6 +146,8 @@ def nc2zarr(
                                     output_path=output_path,
                                     output_overwrite=overwrite,
                                     output_append=append,
+                                    output_adjust_metadata=adjust_metadata,
+                                    finalize_only=finalize_only,
                                     verbosity=verbose if verbose else None,
                                     dry_run=dry_run)
         Converter(**config_kwargs).run()

--- a/nc2zarr/cli.py
+++ b/nc2zarr/cli.py
@@ -111,7 +111,7 @@ def nc2zarr(
     configurations and thus override settings in any CONFIG_FILE:
 
     \b
-    [--finalize_only] overrides /finalize_only
+    [--finalize-only] overrides /finalize_only
     [--dry-run] overrides /dry_run
     [--verbose] overrides /verbosity
 

--- a/nc2zarr/converter.py
+++ b/nc2zarr/converter.py
@@ -114,7 +114,7 @@ class Converter:
 
         if output_overwrite and output_append:
             raise ConverterError('Output overwrite and append flags '
-                                 'cannot be given both.')
+                                 'cannot both be given.')
 
         if output_metadata \
                 and (not isinstance(output_metadata, dict)

--- a/nc2zarr/converter.py
+++ b/nc2zarr/converter.py
@@ -195,6 +195,7 @@ class Converter:
                                output_retry_kwargs=self.output_retry,
                                input_decode_cf=self.input_decode_cf,
                                input_paths=input_paths,
+                               finalize_only=self.finalize_only,
                                dry_run=self.dry_run)
 
         if not self.finalize_only:

--- a/nc2zarr/converter.py
+++ b/nc2zarr/converter.py
@@ -35,7 +35,7 @@ from .writer import DatasetWriter
 
 class Converter:
     """
-    TODO: describe me any py params.
+    TODO: describe me and my params.
 
     :param input_paths:
     :param input_sort_by:
@@ -58,6 +58,8 @@ class Converter:
            If there is no existing dataset, one will be created regardless
            of the value of this parameter.
     :param output_append_dim:
+    :param output_adjust_metadata:
+    :param output_metadata:
     :param output_s3:
     :param output_custom_postprocessor:
     :param dry_run:
@@ -84,6 +86,8 @@ class Converter:
                  output_overwrite: bool = False,
                  output_append: bool = False,
                  output_append_dim: str = None,
+                 output_adjust_metadata: bool = False,
+                 output_metadata: Dict[str, Any] = None,
                  output_s3: Dict[str, Any] = None,
                  output_retry: Dict[str, Any] = None,
                  output_custom_postprocessor: str = False,
@@ -107,7 +111,14 @@ class Converter:
         output_append_dim = input_concat_dim or DEFAULT_OUTPUT_APPEND_DIM_NAME
 
         if output_overwrite and output_append:
-            raise ConverterError('Output overwrite and append flags cannot be given both.')
+            raise ConverterError('Output overwrite and append flags '
+                                 'cannot be given both.')
+
+        if output_metadata \
+                and (not isinstance(output_metadata, dict)
+                     or any(not isinstance(k, str) for k in output_metadata)):
+            raise ConverterError('Output metadata must be a mapping '
+                                 'from attribute names to values.')
 
         self.input_paths = input_paths
         self.input_sort_by = input_sort_by
@@ -129,6 +140,8 @@ class Converter:
         self.output_overwrite = output_overwrite
         self.output_append = output_append
         self.output_append_dim = output_append_dim
+        self.output_adjust_metadata = output_adjust_metadata
+        self.output_metadata = output_metadata
         self.output_s3 = output_s3
         self.output_retry = output_retry
         self.dry_run = dry_run
@@ -168,9 +181,12 @@ class Converter:
                                output_overwrite=self.output_overwrite,
                                output_append=self.output_append,
                                output_append_dim=self.output_append_dim,
+                               output_adjust_metadata=self.output_adjust_metadata,
+                               output_metadata=self.output_metadata,
                                output_s3_kwargs=self.output_s3,
                                output_retry_kwargs=self.output_retry,
                                input_decode_cf=self.input_decode_cf,
+                               input_paths=self.input_paths,
                                dry_run=self.dry_run)
 
         append = None
@@ -179,3 +195,5 @@ class Converter:
             writer.write_dataset(output_dataset, encoding=output_encoding, append=append)
             input_dataset.close()
             append = True
+
+        writer.finalize()

--- a/nc2zarr/res/config-template.yml
+++ b/nc2zarr/res/config-template.yml
@@ -168,6 +168,19 @@ output:
   # Append dimension. Defaults to input/concat_dim or "time".
   append_dim: false
 
+  # Whether to adjust output metadata (global attributes)
+  # After the last write/append. This will adjust the
+  # following global attributes
+  # - "history"
+  # - "source"
+  # - "time_coverage_start" (and "start_time" if existed before)
+  # - "time_coverage_end" (and "stop_time" if existed before)
+  adjust_metadata: false
+
+  # Extra metadata (global attributes) used to update
+  # after the last write/append.
+  metadata: { }
+
   # Object storage file system configuration.
   # If given, content are the keyword arguments passed to s3fs.S3FileSystem().
   # See https://s3fs.readthedocs.io/en/latest/api.html#s3fs.core.S3FileSystem

--- a/nc2zarr/writer.py
+++ b/nc2zarr/writer.py
@@ -247,7 +247,7 @@ class DatasetWriter:
     @classmethod
     def _get_history_metadata(cls, dataset: xr.Dataset):
         now = _np_timestamp_to_str(np.array(datetime.datetime.utcnow(), dtype=np.datetime64))
-        present = f"{now}: converted by nc2zarr, version {version}"
+        present = f"{now} - converted by nc2zarr, version {version}"
         history = dataset.attrs.get("history")
         return ((history + '\n') if history else '') + present
 

--- a/nc2zarr/writer.py
+++ b/nc2zarr/writer.py
@@ -221,7 +221,8 @@ class DatasetWriter:
             if self._output_metadata:
                 adjusted_metadata.update(self._output_metadata)
 
-            LOGGER.info('Metadata update:\n', json.dumps(adjusted_metadata, indent=2))
+            LOGGER.info(f'Metadata update:\n'
+                        f'{json.dumps(adjusted_metadata, indent=2)}')
 
             if not self._dry_run:
                 self._ensure_store()

--- a/nc2zarr/writer.py
+++ b/nc2zarr/writer.py
@@ -217,6 +217,8 @@ class DatasetWriter:
                 # Externally modify attributes
                 with zarr.open_group(self._output_store, cache_attrs=False) as group:
                     group.attrs.update(adjusted_metadata)
+                if self._output_consolidated:
+                    zarr.convenience.consolidate_metadata(self._output_store)
             else:
                 LOGGER.warning('Updating of metadata disabled, dry run!')
 

--- a/nc2zarr/writer.py
+++ b/nc2zarr/writer.py
@@ -237,10 +237,11 @@ class DatasetWriter:
     def _get_source_metadata(self, dataset: xr.Dataset):
         source = None
         if self._input_paths:
-            # Note, currently we only name root sources, our NetCDF files.
-            nc_paths = ', '.join(path for path in self._input_paths if path.endswith('.nc'))
-            source = dataset.attrs.get('source')
-            source = ((source + ',\n') if source else '') + nc_paths
+            # Note, currently we only name root sources = our NetCDF files.
+            nc_paths = [path for path in self._input_paths if path.endswith('.nc')]
+            if nc_paths:
+                source = dataset.attrs.get('source')
+                source = ((source + ',\n') if source else '') + ', '.join(nc_paths)
         return source
 
     @classmethod

--- a/nc2zarr/writer.py
+++ b/nc2zarr/writer.py
@@ -249,8 +249,8 @@ class DatasetWriter:
                 time_coverage_start = _xr_timestamp_to_str(time_bnds[0, 0])
                 time_coverage_end = _xr_timestamp_to_str(time_bnds[-1, 1])
             else:
-                time_coverage_start = _xr_timestamp_to_str(dataset.time[0])
-                time_coverage_end = _xr_timestamp_to_str(dataset.time[-1])
+                time_coverage_start = _xr_timestamp_to_str(time[0])
+                time_coverage_end = _xr_timestamp_to_str(time[-1])
         return time_coverage_start, time_coverage_end
 
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -103,7 +103,8 @@ def delete_path(path, ignore_errors=False):
 def new_test_dataset(w: int = 36,
                      h: int = 18,
                      day: int = None,
-                     chunked: bool = False) -> xr.Dataset:
+                     chunked: bool = False,
+                     add_time_bnds: bool = False) -> xr.Dataset:
     res = 180 / h
     lon = xr.DataArray(np.linspace(-180 + res, 180 - res, num=w), dims=('lon',))
     lat = xr.DataArray(np.linspace(-90 + res, 90 - res, num=h), dims=('lat',))
@@ -122,7 +123,19 @@ def new_test_dataset(w: int = 36,
             calendar="proleptic_gregorian",
             units="seconds since 1970-01-01 00:00:00"
         )
-        coords = dict(lon=lon, lat=lat, time=time)
+        if add_time_bnds:
+            time.attrs['bounds'] = 'time_bnds'
+            time_bnds = xr.DataArray(np.array([['2020-12-{:02d}T09:30:00'.format(day),
+                                                '2020-12-{:02d}T10:30:00'.format(day)]],
+                                              dtype='datetime64[s]'),
+                                     dims=('time', 'bnds'))
+            time_bnds.encoding.update(
+                calendar="proleptic_gregorian",
+                units="seconds since 1970-01-01 00:00:00"
+            )
+            coords = dict(lon=lon, lat=lat, time=time, time_bnds=time_bnds)
+        else:
+            coords = dict(lon=lon, lat=lat, time=time)
 
     r_ui16 = xr.DataArray(
         np.random.randint(0, 1000, size=var_shape).astype(dtype=np.uint16),

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -174,7 +174,28 @@ class MainTest(unittest.TestCase, IOCollector, ZarrOutputTestMixin):
             Converter()
         self.assertEqual('At least one input must be given.', f'{cm.exception}')
 
-    def test_both_append_dim_and_concat_dim(self):
-        with self.assertRaises(ConverterError) as cm:
+    def test_both_output_append_dim_and_overwrite(self):
+        with self.assertRaises(ConverterError) as e:
             Converter(input_paths='inputs/*.nc', output_overwrite=True, output_append=True)
-        self.assertEqual('Output overwrite and append flags cannot be given both.', f'{cm.exception}')
+        self.assertEqual(('Output overwrite and append '
+                          'flags cannot be given both.',),
+                         e.exception.args)
+
+    def test_invalid_output_metadata(self):
+        self.add_path('my.zarr')
+
+        with self.assertRaises(ConverterError) as e:
+            # noinspection PyTypeChecker
+            Converter(input_paths='inputs/*.nc',
+                      output_metadata=[('comment', 'This dataset is crap.')])
+        self.assertEqual(('Output metadata must be a '
+                          'mapping from attribute names to values.',),
+                         e.exception.args)
+
+        with self.assertRaises(ConverterError) as e:
+            # noinspection PyTypeChecker
+            Converter(input_paths='inputs/*.nc',
+                      output_metadata={12: 'This dataset is crap.'})
+        self.assertEqual(('Output metadata must be a '
+                          'mapping from attribute names to values.',),
+                         e.exception.args)

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -178,7 +178,7 @@ class MainTest(unittest.TestCase, IOCollector, ZarrOutputTestMixin):
         with self.assertRaises(ConverterError) as e:
             Converter(input_paths='inputs/*.nc', output_overwrite=True, output_append=True)
         self.assertEqual(('Output overwrite and append '
-                          'flags cannot be given both.',),
+                          'flags cannot both be given.',),
                          e.exception.args)
 
     def test_invalid_output_metadata(self):
@@ -187,7 +187,7 @@ class MainTest(unittest.TestCase, IOCollector, ZarrOutputTestMixin):
         with self.assertRaises(ConverterError) as e:
             # noinspection PyTypeChecker
             Converter(input_paths='inputs/*.nc',
-                      output_metadata=[('comment', 'This dataset is crap.')])
+                      output_metadata=[('comment', 'This dataset is a test.')])
         self.assertEqual(('Output metadata must be a '
                           'mapping from attribute names to values.',),
                          e.exception.args)
@@ -195,7 +195,7 @@ class MainTest(unittest.TestCase, IOCollector, ZarrOutputTestMixin):
         with self.assertRaises(ConverterError) as e:
             # noinspection PyTypeChecker
             Converter(input_paths='inputs/*.nc',
-                      output_metadata={12: 'This dataset is crap.'})
+                      output_metadata={12: 'This dataset is a test.'})
         self.assertEqual(('Output metadata must be a '
                           'mapping from attribute names to values.',),
                          e.exception.args)

--- a/tests/test_preprocessor.py
+++ b/tests/test_preprocessor.py
@@ -51,6 +51,22 @@ class DatasetPreProcessorTest(unittest.TestCase):
         self.assertIn('time', new_ds)
         self.assertEqual(ds.time, new_ds.time)
 
+    def test_time_var_is_scalar(self):
+        ds = new_test_dataset(day=2)
+        time = ds.time
+        ds = ds.rename_vars({'time': 't'})
+        ds = ds.swap_dims({'time': 't'})
+        ds = ds.assign_coords({'time': xr.DataArray(time[0].values.item(), dims=())})
+        ds = ds.drop_vars('t')
+        pre_processor = DatasetPreProcessor(input_variables=None, input_concat_dim='time')
+        new_ds = pre_processor.preprocess_dataset(ds)
+        self.assertIsInstance(new_ds, xr.Dataset)
+        self.assertAllInDataset(['r_ui16', 'r_ui16', 'r_i32', 'lon', 'lat', 'time'], new_ds)
+        self.assertIn('time', new_ds)
+        self.assertEqual(('time',), new_ds.time.dims)
+        self.assertEqual((1,), new_ds.time.shape)
+        self.assertEqual(ds.time, new_ds.time)
+
     def test_adds_time_dim_from_iso_format_attrs(self):
         ds = new_test_dataset(day=None)
         ds.attrs.update(time_coverage_start='2020-09-08 10:30:00',

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -105,7 +105,7 @@ class DatasetWriterTest(unittest.TestCase, IOCollector):
         self.add_path('my.zarr')
         writer = DatasetWriter('my.zarr',
                                output_append=True,
-                               output_metadata=dict(comment='This dataset is crap.'))
+                               output_metadata=dict(comment='This is a test.'))
         for i in range(3):
             ds = new_test_dataset(day=i + 1)
             writer.write_dataset(ds)
@@ -114,7 +114,7 @@ class DatasetWriterTest(unittest.TestCase, IOCollector):
         writer.finalize_dataset()
         with xr.open_zarr('my.zarr') as ds:
             self.assertIn('comment', ds.attrs)
-            self.assertEqual('This dataset is crap.', ds.attrs['comment'])
+            self.assertEqual('This is a test.', ds.attrs['comment'])
 
     def test_finalize_only_and_append(self):
         self.add_path('my.zarr')
@@ -134,7 +134,7 @@ class DatasetWriterTest(unittest.TestCase, IOCollector):
         writer = DatasetWriter('my.zarr',
                                finalize_only=True,
                                output_append=True,
-                               output_metadata=dict(comment='This dataset is crap.'))
+                               output_metadata=dict(comment='This is a test.'))
 
         with self.assertRaises(FileNotFoundError) as e:
             writer.finalize_dataset()

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -78,7 +78,7 @@ class DatasetWriterTest(unittest.TestCase, IOCollector):
             self.assertNotIn('source', ds.attrs)
             self.assertNotIn('time_coverage_start', ds.attrs)
             self.assertNotIn('time_coverage_end', ds.attrs)
-        writer.finalize()
+        writer.finalize_dataset()
         with xr.open_zarr('my.zarr') as ds:
             self.assertIn('history', ds.attrs)
             self.assertIn('source', ds.attrs)
@@ -94,7 +94,7 @@ class DatasetWriterTest(unittest.TestCase, IOCollector):
         for i in range(3):
             ds = new_test_dataset(day=i + 1, add_time_bnds=True)
             writer.write_dataset(ds)
-        writer.finalize()
+        writer.finalize_dataset()
         with xr.open_zarr('my.zarr') as ds:
             self.assertIn('time_coverage_start', ds.attrs)
             self.assertEqual('2020-12-01 09:30:00', ds.attrs['time_coverage_start'])
@@ -111,7 +111,7 @@ class DatasetWriterTest(unittest.TestCase, IOCollector):
             writer.write_dataset(ds)
         with xr.open_zarr('my.zarr') as ds:
             self.assertNotIn('comment', ds.attrs)
-        writer.finalize()
+        writer.finalize_dataset()
         with xr.open_zarr('my.zarr') as ds:
             self.assertIn('comment', ds.attrs)
             self.assertEqual('This dataset is crap.', ds.attrs['comment'])
@@ -201,7 +201,7 @@ class DatasetWriterTest(unittest.TestCase, IOCollector):
             with xr.open_zarr(src_path, decode_cf=False) as src_dataset:
                 writer.write_dataset(src_dataset, append=i > 0)
 
-        self._assert_time_slices_ok(dst_path, src_path_pat, n)
+        self.assertTimeSlicesOk(dst_path, src_path_pat, n)
 
     # see also https://github.com/pydata/xarray/issues/4412
     def test_append_with_input_decode_cf_xarray(self):
@@ -227,7 +227,7 @@ class DatasetWriterTest(unittest.TestCase, IOCollector):
                         src_dataset[var_name].attrs = {}
                     src_dataset.to_zarr(dst_path, append_dim='time')
 
-        self._assert_time_slices_ok(dst_path, src_path_pat, n)
+        self.assertTimeSlicesOk(dst_path, src_path_pat, n)
 
     def test_appending_vars_that_lack_append_dim(self):
 
@@ -255,10 +255,10 @@ class DatasetWriterTest(unittest.TestCase, IOCollector):
             with xr.open_zarr(src_path, decode_cf=False) as src_dataset:
                 writer.write_dataset(src_dataset, append=i > 0)
 
-        self._assert_time_slices_ok(dst_path, src_path_pat, n)
+        self.assertTimeSlicesOk(dst_path, src_path_pat, n)
 
     @classmethod
-    def _assert_time_slices_ok(cls, dst_path, src_path_pat, n):
+    def assertTimeSlicesOk(cls, dst_path, src_path_pat, n):
         with xr.open_zarr(dst_path, decode_cf=False) as ds:
             for i in range(0, n):
                 src_path = src_path_pat.format(i)

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -159,8 +159,9 @@ class DatasetWriterTest(unittest.TestCase, IOCollector):
         self.assertTrue(os.path.isfile('my.zarr/.zmetadata'))
         with open('my.zarr/.zmetadata') as fp:
             metadata = json.load(fp)
+        self.assertIn('metadata', metadata)
         self.assertEqual({},
-                         metadata.get('.zattrs'))
+                         metadata['metadata'].get('.zattrs'))
 
     def test_finalize_only_and_consolidate_if_not_specified(self):
         self.add_path('my.zarr')
@@ -181,8 +182,9 @@ class DatasetWriterTest(unittest.TestCase, IOCollector):
         self.assertTrue(os.path.isfile('my.zarr/.zmetadata'))
         with open('my.zarr/.zmetadata') as fp:
             metadata = json.load(fp)
+        self.assertIn('metadata', metadata)
         self.assertEqual({'comment': 'This dataset is a test.'},
-                         metadata.get('.zattrs'))
+                         metadata['metadata'].get('.zattrs'))
 
     def test_local_dry_run_for_existing(self):
         self.add_path('my.zarr')

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -19,6 +19,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+import json
 import os.path
 import unittest
 import uuid
@@ -105,7 +106,7 @@ class DatasetWriterTest(unittest.TestCase, IOCollector):
         self.add_path('my.zarr')
         writer = DatasetWriter('my.zarr',
                                output_append=True,
-                               output_metadata=dict(comment='This is a test.'))
+                               output_metadata=dict(comment='This dataset is a test.'))
         for i in range(3):
             ds = new_test_dataset(day=i + 1)
             writer.write_dataset(ds)
@@ -114,7 +115,7 @@ class DatasetWriterTest(unittest.TestCase, IOCollector):
         writer.finalize_dataset()
         with xr.open_zarr('my.zarr') as ds:
             self.assertIn('comment', ds.attrs)
-            self.assertEqual('This is a test.', ds.attrs['comment'])
+            self.assertEqual('This dataset is a test.', ds.attrs['comment'])
 
     def test_finalize_only_and_append(self):
         self.add_path('my.zarr')
@@ -134,28 +135,54 @@ class DatasetWriterTest(unittest.TestCase, IOCollector):
         writer = DatasetWriter('my.zarr',
                                finalize_only=True,
                                output_append=True,
-                               output_metadata=dict(comment='This is a test.'))
+                               output_metadata=dict(comment='This dataset is a test.'))
 
         with self.assertRaises(FileNotFoundError) as e:
             writer.finalize_dataset()
         self.assertEqual(('output path not found: my.zarr',),
                          e.exception.args)
 
-    def test_finalize_only_and_consolidate(self):
+    def test_finalize_only_and_consolidate_if_specified(self):
         self.add_path('my.zarr')
         ds = new_test_dataset(day=1)
-        writer = DatasetWriter('my.zarr', output_overwrite=True)
+        writer = DatasetWriter('my.zarr',
+                               output_overwrite=True)
         writer.write_dataset(ds)
         writer.finalize_dataset()
         self.assertTrue(os.path.isdir('my.zarr'))
         self.assertFalse(os.path.isfile('my.zarr/.zmetadata'))
         writer = DatasetWriter('my.zarr',
-                               output_overwrite=True,
                                output_consolidated=True,
                                finalize_only=True)
         writer.finalize_dataset()
         self.assertTrue(os.path.isdir('my.zarr'))
         self.assertTrue(os.path.isfile('my.zarr/.zmetadata'))
+        with open('my.zarr/.zmetadata') as fp:
+            metadata = json.load(fp)
+        self.assertEqual({},
+                         metadata.get('.zattrs'))
+
+    def test_finalize_only_and_consolidate_if_not_specified(self):
+        self.add_path('my.zarr')
+        ds = new_test_dataset(day=1)
+        writer = DatasetWriter('my.zarr',
+                               output_consolidated=True,
+                               output_overwrite=True)
+        writer.write_dataset(ds)
+        writer.finalize_dataset()
+        self.assertTrue(os.path.isdir('my.zarr'))
+        self.assertTrue(os.path.isfile('my.zarr/.zmetadata'))
+        writer = DatasetWriter('my.zarr',
+                               output_consolidated=False,
+                               output_metadata=dict(comment='This dataset is a test.'),
+                               finalize_only=True)
+        writer.finalize_dataset()
+        self.assertTrue(os.path.isdir('my.zarr'))
+        self.assertTrue(os.path.isfile('my.zarr/.zmetadata'))
+        with open('my.zarr/.zmetadata') as fp:
+            metadata = json.load(fp)
+        self.assertEqual({'comment': 'This dataset is a test.'},
+                         metadata.get('.zattrs'))
 
     def test_local_dry_run_for_existing(self):
         self.add_path('my.zarr')


### PR DESCRIPTION
Closes #20
Closes #34

Whether to adjust output metadata (global attributes) after the last write/append can now be forced by the new
`output.adjust_metadata` setting whose default is `false`. If set to `true`, this will adjust the following metadata attributes
  - "history"
  - "source"
  - "time_coverage_start"
  - "time_coverage_end" 
    
In addition, extra metadata (global attributes) can now be added after the last write/append using the new setting `output.metadata` whose value is a mapping from attribute names to values. 

The above functionality is also reflected in two new CLI options  `--adjust-metadata` and `--finalize-only`. In combination, they  can be used to later adjust metadata in already existing Zarr datasets.
