### PR TITLE
Handle consolidated Zarrs correctly when appending

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 ## nc2zarr Change History
 
+### Version 1.3.0 (in development)
+
+* Handle consolidated Zarrs correctly when appending data (fixes #47).
+
 ### Version 1.2.2
 
 * Fix incorrect version number.

--- a/nc2zarr/dataslice.py
+++ b/nc2zarr/dataslice.py
@@ -126,6 +126,13 @@ def update_slice(store: Union[str, MutableMapping],
     append_dim_var_names = []
     encoding = {}
 
+    # Neither Zarr nor xarray offer an explicit API function to check whether
+    # a Zarr is consolidated. Here we use the workaround of attempting to
+    # open as consolidated, and catching the resulting exception if this
+    # isn't possible. In the case of a consolidated Zarr, there is a slight
+    # inefficiency, since the consolidated metadata object is fetched twice
+    # (by Zarr and thereafter by xarray). See comments on PR #48 for
+    # discussion of possible optimizations.
     consolidated = True
     try:
         _ = zarr.open_consolidated(store)

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -79,13 +79,13 @@ class DatasetWriterTest(unittest.TestCase, IOCollector):
         for i in range(3):
             ds = new_test_dataset(day=i + 1)
             writer.write_dataset(ds)
-        with xr.open_zarr('my.zarr') as ds:
+        with xr.open_zarr('my.zarr', consolidated=False) as ds:
             self.assertNotIn('history', ds.attrs)
             self.assertNotIn('source', ds.attrs)
             self.assertNotIn('time_coverage_start', ds.attrs)
             self.assertNotIn('time_coverage_end', ds.attrs)
         writer.finalize_dataset()
-        with xr.open_zarr('my.zarr') as ds:
+        with xr.open_zarr('my.zarr', consolidated=False) as ds:
             self.assertIn('history', ds.attrs)
             self.assertIn('source', ds.attrs)
             self.assertEqual('a.nc, b.nc', ds.attrs['source'])
@@ -96,16 +96,19 @@ class DatasetWriterTest(unittest.TestCase, IOCollector):
 
     def test_finalize_adjusts_metadata_with_time_bnds(self):
         self.add_path('my.zarr')
-        writer = DatasetWriter('my.zarr', output_append=True, output_adjust_metadata=True)
+        writer = DatasetWriter('my.zarr', output_append=True,
+                               output_adjust_metadata=True)
         for i in range(3):
             ds = new_test_dataset(day=i + 1, add_time_bnds=True)
             writer.write_dataset(ds)
         writer.finalize_dataset()
-        with xr.open_zarr('my.zarr') as ds:
+        with xr.open_zarr('my.zarr', consolidated=False) as ds:
             self.assertIn('time_coverage_start', ds.attrs)
-            self.assertEqual('2020-12-01 09:30:00', ds.attrs['time_coverage_start'])
+            self.assertEqual('2020-12-01 09:30:00',
+                             ds.attrs['time_coverage_start'])
             self.assertIn('time_coverage_end', ds.attrs)
-            self.assertEqual('2020-12-03 10:30:00', ds.attrs['time_coverage_end'])
+            self.assertEqual('2020-12-03 10:30:00',
+                             ds.attrs['time_coverage_end'])
 
     def test_finalize_updates_metadata(self):
         self.add_path('my.zarr')
@@ -115,10 +118,10 @@ class DatasetWriterTest(unittest.TestCase, IOCollector):
         for i in range(3):
             ds = new_test_dataset(day=i + 1)
             writer.write_dataset(ds)
-        with xr.open_zarr('my.zarr') as ds:
+        with xr.open_zarr('my.zarr', consolidated=False) as ds:
             self.assertNotIn('comment', ds.attrs)
         writer.finalize_dataset()
-        with xr.open_zarr('my.zarr') as ds:
+        with xr.open_zarr('my.zarr', consolidated=False) as ds:
             self.assertIn('comment', ds.attrs)
             self.assertEqual('This dataset is a test.', ds.attrs['comment'])
 
@@ -230,15 +233,16 @@ class DatasetWriterTest(unittest.TestCase, IOCollector):
 
     def test_local_postprocessor(self):
         self.add_path('my.zarr')
-        writer = DatasetWriter('my.zarr',
-                               output_overwrite=False,
-                               output_custom_postprocessor='tests.test_writer:my_postprocessor')
+        writer = DatasetWriter(
+            'my.zarr',
+            output_overwrite=False,
+            output_custom_postprocessor='tests.test_writer:my_postprocessor')
         ds = new_test_dataset(day=1)
         self.assertNotIn('crs', ds)
 
         writer.write_dataset(ds)
         self.assertTrue(os.path.isdir('my.zarr'))
-        with xr.open_zarr('my.zarr') as ds:
+        with xr.open_zarr('my.zarr', consolidated=False) as ds:
             self.assertIn('crs', ds)
 
     # noinspection PyMethodMayBeStatic
@@ -462,7 +466,7 @@ class DatasetWriterTest(unittest.TestCase, IOCollector):
 
     @classmethod
     def assertTimeSlicesOk(cls, dst_path, src_path_pat, n):
-        with xr.open_zarr(dst_path, decode_cf=False) as ds:
+        with xr.open_zarr(dst_path, decode_cf=False, consolidated=False) as ds:
             for i in range(0, n):
                 src_path = src_path_pat.format(i)
                 with xr.open_zarr(src_path, decode_cf=False) as src_dataset:


### PR DESCRIPTION
Fixes #47 .

The important change in this PR consists of a few additional lines in `dataslice.py` to detect and correctly handle consolidated Zarrs. Apart from that, it's just updates and improvements to unit tests.