### PR TITLE
Require s3fs version >=2022.1.0

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -14,7 +14,7 @@ dependencies:
   - pandas
   - pyyaml
   - retry
-  - s3fs
+  - s3fs >=2022.1.0
   - xarray
   - zarr
   # Testing


### PR DESCRIPTION
Fixes #53 .

The recent CI failures (‘Install s3fs to access S3’) seem to be
connected with an old botocore version that isn't Python 3.10
compatible (the well-known collections.abc vs. collections import
error). micromamba in CI chooses an old s3fs version -- legally,
since there were no version constraints -- which in turn allows
the old botocore version as a dependency.

s3fs 2022.1.0 requires aiobotocore ~=2.1.0, and aiobotocore 2.1.0
requires botocore>=1.23.24,<1.23.25, which no longer contains the
vendored version of the requests library that was causing the
import error.

Note: one unit test is still failing: ‘tests/test_converter.py::MainTest::test_multi_file_with_defaults - ValueError: When combine='by_coords', passing a value for `concat_dim` has no effect. To manually combine along a specific dimension you should instead specify com...’. This test failure is unrelated to Issue #53 and not addressed by this PR.