### PR TITLE
Allow private S3 bucket as inputs

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -10,6 +10,7 @@ dependencies:
   - dask
   - fsspec
   - netcdf4
+  - h5netcdf
   - numpy
   - pandas
   - pyyaml

--- a/nc2zarr/opener.py
+++ b/nc2zarr/opener.py
@@ -99,7 +99,7 @@ class DatasetOpener:
                               f'combining by coordinates')
             # TODO: this bit of the code needs more work for different cases
             # e.g mixed sources - s3, local, glob are declared in `paths`
-            if ('s3://' in input_path for input_path in input_paths):
+            if (input_path.startswith('s3://') for input_path in input_paths):
                 fileset = [self.s3.open(input_path) for input_path in input_paths]
             else:
                 fileset = input_paths
@@ -121,7 +121,7 @@ class DatasetOpener:
             -> Iterator[xr.Dataset]:
         n = len(input_paths)
         for i in range(n):
-            if 's3://' in input_paths[i]:
+            if input_paths[i].startswith('s3://'):
                 input_file = self.s3.open(input_paths[i])
             else:
                 input_file = input_paths[i]
@@ -139,7 +139,7 @@ class DatasetOpener:
         if not self._input_prefetch_chunks:
             return None
         with log_duration('Pre-fetching chunks'):
-            if 's3://' in input_file:
+            if input_file.startswith('s3://'):
                 file = self.s3.open(input_file)
             else:
                 file = input_file
@@ -182,7 +182,7 @@ class DatasetOpener:
         resolved_input_files = []
         for input_path in input_paths:
             input_path = os.path.expanduser(input_path)
-            if 's3://' in input_path:
+            if input_path.startswith('s3://'):
                 if '*' in input_path or '?' in input_path:
                     glob_result = cls.s3.glob(input_path)
                     if not glob_result:

--- a/nc2zarr/opener.py
+++ b/nc2zarr/opener.py
@@ -101,13 +101,11 @@ class DatasetOpener:
             # e.g mixed sources - s3, local, glob are declared in `paths`
             if ('s3://' in input_path for input_path in input_paths):
                 fileset = [self.s3.open(input_path) for input_path in input_paths]
-                engine = 'h5netcdf'
             else:
                 fileset = input_paths
-                engine = self._input_engine
             ds = xr.open_mfdataset(
                 fileset,
-                engine=engine,
+                engine=self._input_engine,
                 preprocess=preprocess,
                 concat_dim=self._input_concat_dim,
                 decode_cf=self._input_decode_cf,
@@ -125,14 +123,12 @@ class DatasetOpener:
         for i in range(n):
             if 's3://' in input_paths[i]:
                 input_file = self.s3.open(input_paths[i])
-                engine = 'h5netcdf'
             else:
                 input_file = input_paths[i]
-                engine = self._get_engine(input_file)
             LOGGER.info(f'Processing input {i + 1} of {n}: {input_paths[i]}')
             with log_duration('Opening'):
                 ds = xr.open_dataset(input_file,
-                                     engine=engine,
+                                     engine=self._get_engine(input_file),
                                      decode_cf=self._input_decode_cf,
                                      chunks=chunks)
                 if preprocess:
@@ -145,12 +141,10 @@ class DatasetOpener:
         with log_duration('Pre-fetching chunks'):
             if 's3://' in input_file:
                 file = self.s3.open(input_file)
-                engine = 'h5netcdf'
             else:
                 file = input_file
-                engine = self._get_engine(input_file)
             with xr.open_dataset(file,
-                                 engine=engine,
+                                 engine=self._get_engine(file),
                                  decode_cf=self._input_decode_cf) as ds:
                 chunk_sizes = dict()
                 for var in ds.data_vars.values():

--- a/nc2zarr/opener.py
+++ b/nc2zarr/opener.py
@@ -25,7 +25,6 @@ import warnings
 from typing import List, Optional, Iterator, Callable, Union, Dict, Hashable
 
 import s3fs
-s3 = s3fs.S3FileSystem(anon=False)
 
 import xarray as xr
 
@@ -35,6 +34,10 @@ from .log import log_duration
 
 
 class DatasetOpener:
+
+    # TODO: passing anon value from config file
+    s3 = s3fs.S3FileSystem(anon=False)
+
     def __init__(self,
                  input_paths: Union[str, List[str]],
                  *,
@@ -94,8 +97,8 @@ class DatasetOpener:
                 combine = 'by_coords'
                 warnings.warn(f'input/concat_dim is not specified, '
                               f'combining by coordinates')
-            if 's3' in input_paths[0]:
-                fileset = [s3.open(input_path) for input_path in input_paths]
+            if any('s3://' in input_path for input_path in input_paths):
+                fileset = [self.s3.open(input_path) for input_path in input_paths]
                 engine = 'h5netcdf'
             else:
                 fileset = input_paths
@@ -118,8 +121,8 @@ class DatasetOpener:
             -> Iterator[xr.Dataset]:
         n = len(input_paths)
         for i in range(n):
-            if 's3' in input_paths[i]:
-                input_file = s3.open(input_paths[i])
+            if 's3://' in input_paths[i]:
+                input_file = self.s3.open(input_paths[i])
                 engine = 'h5netcdf'
             else:
                 input_file = input_paths[i]
@@ -138,8 +141,8 @@ class DatasetOpener:
         if not self._input_prefetch_chunks:
             return None
         with log_duration('Pre-fetching chunks'):
-            if 's3' in input_file:
-                file = s3.open(input_file)
+            if 's3://' in input_file:
+                file = self.s3.open(input_file)
                 engine = 'h5netcdf'
             else:
                 file = input_file
@@ -183,15 +186,15 @@ class DatasetOpener:
         resolved_input_files = []
         for input_path in input_paths:
             input_path = os.path.expanduser(input_path)
-            if 's3' in input_path:
+            if 's3://' in input_path:
                 if '*' in input_path or '?' in input_path:
-                    glob_result = s3.glob(input_path)
+                    glob_result = cls.s3.glob(input_path)
                     if not glob_result:
                         raise ConverterError(f'No S3 inputs found for wildcard: "{input_path}"')
                     resolved_input_files.extend(['s3://' + path for path in glob_result])
                 else:
                     try:
-                        s3.ls(input_path)
+                        cls.s3.ls(input_path)
                         resolved_input_files.append(input_path)
                     except FileNotFoundError:
                         raise ConverterError(f'S3 input not found: "{input_path}"')

--- a/nc2zarr/opener.py
+++ b/nc2zarr/opener.py
@@ -97,7 +97,9 @@ class DatasetOpener:
                 combine = 'by_coords'
                 warnings.warn(f'input/concat_dim is not specified, '
                               f'combining by coordinates')
-            if any('s3://' in input_path for input_path in input_paths):
+            # TODO: this bit of the code needs more work for different cases
+            # e.g mixed sources - s3, local, glob are declared in `paths`
+            if ('s3://' in input_path for input_path in input_paths):
                 fileset = [self.s3.open(input_path) for input_path in input_paths]
                 engine = 'h5netcdf'
             else:


### PR DESCRIPTION
I hope this contribution will be helpful and as a thank you for providing `nc2zarr` as open-source.

I needed to load NetCDF files from a private S3 bucket and was able to solve that with the changes in this commit.

If NetCDF files are read from a public bucket, just need to change `anon=True`, then re-issue `python setup.py develop`

```python
s3 = s3fs.S3FileSystem(anon=False)
```

I believe it'll be possible to make S3 as inputs feature comprehensive just like what `nc2zarr` can currently do with S3 as outputs. However, it's outside the scope of my intention so I didn't invest much time in it.

I deployed and ran `nc2zarr` directly from an AWS SageMaker notebook that has read/write access to the target private S3 bucket. If accessing the S3 bucket from a different workstation, just need to follow AWS authentication guidelines (e.g. `~/.aws/credentials` and should be fine, make sure to set up the environment variables `export AWS_PROFILE=<profile-name>` (`~/.aws/config`) if specific IAM roles required before running `nc2zarr`.

With these changes, S3 links can be provided to the `yml` config files either as:

* single link
  ```
  - s3://my-bucket/myfile.nc
  ```

* multiple links
  ```
  - s3://my-bucket/myfile.nc
  - s3://my-bucket/myfile2.nc
  ```

* or with the wildcards:
  ```
  - s3://my-bucket/*.nc
  ```

Thank you and have a lovely day! - *From Tasmania, Australia*
