### PR TITLE
Update tests to work with click >=8.2.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 ### Version 1.2.5 (in development)
 
+* Update tests to work with click >=8.2.0, and require at least this version
+  (#66)
+
 ### Version 1.2.4
 
 * If `input/multi_file` is specified, `concat_dim` is now optional:

--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ channels:
 dependencies:
   - python >=3.7
   # Production
-  - click
+  - click >=8.2.0
   - dask
   - fsspec
   - netcdf4

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -99,7 +99,7 @@ class Nc2zarrCliTest(CliTest, ZarrOutputTestMixin, IOCollector):
         result = self.invoke_cli([])
         self.assertCliResult(result,
                              expected_exit_code=1,
-                             expected_stdout='Error: At least one input must be given.')
+                             expected_stderr='Error: At least one input must be given.')
 
     def test_3_netcdf_inputs(self):
         self.add_inputs('inputs', day_offset=1, num_days=3, add_time_bnds=True)
@@ -174,7 +174,7 @@ class Nc2zarrBatchCliTest(CliTest, ZarrOutputTestMixin, IOCollector):
                                  main=nc2zarr_batch)
         self.assertCliResult(result,
                              expected_exit_code=1,
-                             expected_stdout=['Error: Could not open file',
+                             expected_stderr=['Error: Could not open file',
                                               'config-template.yml',
                                               ': not found'])
 
@@ -190,7 +190,7 @@ class Nc2zarrBatchCliTest(CliTest, ZarrOutputTestMixin, IOCollector):
                                  main=nc2zarr_batch)
         self.assertCliResult(result,
                              expected_exit_code=2,
-                             expected_stdout='Error: reference "${year}" '
+                             expected_stderr='Error: reference "${year}" '
                                              'missing in CONFIG_PATH_TEMPLATE')
 
     def test_scheduler_config_not_found(self):
@@ -206,7 +206,7 @@ class Nc2zarrBatchCliTest(CliTest, ZarrOutputTestMixin, IOCollector):
                                  main=nc2zarr_batch)
         self.assertCliResult(result,
                              expected_exit_code=1,
-                             expected_stdout=['Error: Could not open file ',
+                             expected_stderr=['Error: Could not open file ',
                                               'local.yml',
                                               ': not found'])
 


### PR DESCRIPTION
Several tests are failing because as of v8.2.0, click's `CliRunner` no longer mixes stderr output into its stdout buffer, so tests looking for expected stderr output in stdout don't find it. This commit updates those tests to look in stderr instead and requires click >=8.2.0 in `environment.yml`.
